### PR TITLE
Fix ownership highlighting for renamed files

### DIFF
--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -222,7 +222,7 @@
 
           // If we have owners info, highlight the files we need to review and add role info.
           if (ownersInfo && ownersInfo.currentUserFileCount > 0) {
-            const path = name.replace(/\s\[.*?\]$/i, '').replace(/^\//, '');
+            const path = name.replace(/\s\[.*?\][^]*$/i, '').replace(/^\//, '');
             if (ownersInfo.isCurrentUserResponsibleForFile(path)) {
               fileRow.addClass('file-to-review-row');
               $('<div class="file-owners-role" />').text(`${ownersInfo.currentUserFilesToRole[path]}:`).prependTo(fileRow);


### PR DESCRIPTION
The "name" for a renamed file is actually:

```
<new path> [rename]

renamed from <old path>
```

The replacement we do before attempting to match against the plain file path is not sufficient. It needs to also remove the blank line and "renamed from..." line.