### PR TITLE
Add Code of the Day PR flagging

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,5 +29,6 @@ module.exports = {
     "require-await": "error",
     "require-yield": "error",
     "linebreak-style": 0,
+    "arrow-parens": 0,
   }
 };

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -54,7 +54,7 @@
       applyStickyPullRequestComments();
       addAccessKeysToPullRequestTabs();
       if (/\/DevCentral\/_git\/ASW\//i.test(window.location.pathname)) {
-        addCodeOfDayToggle();
+        addNICodeOfDayToggle();
       }
     } else if (/\/(_pulls|pullrequests)/i.test(window.location.pathname)) {
       sortPullRequestDashboard();
@@ -349,8 +349,8 @@
     });
   }
 
-  // Add a button to toggle flagging a PR discussion thread for Cifra's "Code of the Day" blog posts.
-  function addCodeOfDayToggle() {
+  // Add a button to toggle flagging a PR discussion thread for ASW "Code of the Day" blog posts.
+  function addNICodeOfDayToggle() {
     function getThreadDataFromDOMElement(threadElement) {
       return getPropertyThatStartsWith(threadElement, '__reactEventHandlers$').children[0].props.thread;
     }
@@ -366,13 +366,13 @@
 
     $('.vc-discussion-comments').once('add-cod-flag-support').each(async function () {
       const thread = getThreadDataFromDOMElement(this);
-      const isFlagged = findFlaggedThreadArrayIndex(await getCodeOfTheDayThreadsAsync(), thread.id, currentUser.uniqueName) !== -1;
+      const isFlagged = findFlaggedThreadArrayIndex(await getNICodeOfTheDayThreadsAsync(), thread.id, currentUser.uniqueName) !== -1;
       $(this).find('.vc-discussion-comment-toolbar').each(function () {
         const button = $('<button type="button" class="ms-Button vc-discussion-comment-toolbarbutton ms-Button--icon cod-toggle"><i class="ms-Button-icon cod-toggle-icon bowtie-icon" role="presentation"></i></button>');
         updateButtonForCurrentState(button, isFlagged);
         button.prependTo(this);
         button.click(async (event) => {
-          const isNowFlagged = await toggleThreadFlaggedForCodeOfTheDay(getCurrentPullRequestUrl(), {
+          const isNowFlagged = await toggleThreadFlaggedForNICodeOfTheDay(getCurrentPullRequestUrl(), {
             flaggedDate: new Date().toISOString(),
             flaggedBy: currentUser.uniqueName,
             pullRequestId: getCurrentPullRequestId(),
@@ -661,11 +661,11 @@
   }
 
   // Cached "Code of the Day" thread data.
-  let codeOfTheDayThreadsArray = null;
+  let niCodeOfTheDayThreadsArray = null;
 
-  // Async helper function to flag or unflag a PR discussion thread for "Code of the Day".
-  async function toggleThreadFlaggedForCodeOfTheDay(prUrl, value) {
-    const flaggedComments = await getCodeOfTheDayThreadsAsync();
+  // Async helper function to flag or unflag a PR discussion thread for National Instruments "Code of the Day" blog.
+  async function toggleThreadFlaggedForNICodeOfTheDay(prUrl, value) {
+    const flaggedComments = await getNICodeOfTheDayThreadsAsync();
     const index = findFlaggedThreadArrayIndex(flaggedComments, value.threadId, value.flaggedBy);
     if (index >= 0) {
       // found, so unflag it
@@ -689,11 +689,11 @@
       });
     } catch (e) {
       // invalidate cached value so we re-fetch
-      codeOfTheDayThreadsArray = null;
+      niCodeOfTheDayThreadsArray = null;
     }
 
     // re-query to get the current state of the flagged threads
-    return findFlaggedThreadArrayIndex((await getCodeOfTheDayThreadsAsync()), value.threadId, value.flaggedBy) !== -1;
+    return findFlaggedThreadArrayIndex((await getNICodeOfTheDayThreadsAsync()), value.threadId, value.flaggedBy) !== -1;
   }
 
   // Helper function to find the index of a flagged thread record within the provided array.
@@ -702,11 +702,11 @@
   }
 
   // Async helper function to get the discussion threads (in the current PR) that have been flagged for "Code of the Day."
-  async function getCodeOfTheDayThreadsAsync() {
-    if (!codeOfTheDayThreadsArray) {
-      codeOfTheDayThreadsArray = await getPullRequestProperty(getCurrentPullRequestUrl(), 'NI.CodeOfTheDay', []);
+  async function getNICodeOfTheDayThreadsAsync() {
+    if (!niCodeOfTheDayThreadsArray) {
+      niCodeOfTheDayThreadsArray = await getPullRequestProperty(getCurrentPullRequestUrl(), 'NI.CodeOfTheDay', []);
     }
-    return codeOfTheDayThreadsArray;
+    return niCodeOfTheDayThreadsArray;
   }
 
   // Helper function to access an object member, where the exact, full name of the member is not known.

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -358,8 +358,7 @@
     }
 
     function getThreadDataFromDOMElement(threadElement) {
-      const propName = getPropertyNameStartingWith(threadElement, '__reactEventHandlers$');
-      return threadElement[propName].children[0].props.thread;
+      return getPropertyThatStartsWith(threadElement, '__reactEventHandlers$').children[0].props.thread;
     }
 
     $('.vc-discussion-comments').once('add-cod-flag-support').each(async function () {
@@ -646,8 +645,7 @@
   // Helper function to get the url of the PR that's on screen.
   function getPullRequestUrl() {
     const prDataProvider = pageData['ms.vss-code-web.pull-request-detail-data-provider'];
-    const propertyName = getPropertyNameStartingWith(prDataProvider, 'TFS.VersionControl.PullRequestDetailProvider.PullRequest.');
-    return prDataProvider[propertyName].url;
+    return getPropertyThatStartsWith(prDataProvider, 'TFS.VersionControl.PullRequestDetailProvider.PullRequest.').url;
   }
 
   // Async helper function get info on a single PR. Defaults to the PR that's currently on screen.
@@ -727,8 +725,8 @@
   }
 
   // Helper function to access an object member, where the exact, full name of the member is not known.
-  function getPropertyNameStartingWith(instance, startOfName) {
-    return Object.getOwnPropertyNames(instance).find(x => x.startsWith(startOfName));
+  function getPropertyThatStartsWith(instance, startOfName) {
+    return instance[Object.getOwnPropertyNames(instance).find(x => x.startsWith(startOfName))];
   }
 
   // Async helper function to return reviewer info specific to National Instruments workflows (where this script is used the most).

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -371,8 +371,8 @@
       const iconClass = isFlagged ? flaggedIconClass : notFlaggedIconClass;
       const tooltip = isFlagged ? flaggedTooltip : notFlaggedTooltip;
       $(this).find('.vc-discussion-comment-toolbar').each(function () {
-        $(this).prepend(`<button type="button" id="cod-toggle" class="ms-Button vc-discussion-comment-toolbarbutton ms-Button--icon"><i class="ms-Button-icon cod-toggle-icon bowtie-icon ${iconClass}" role="presentation"></i></button>`);
-        const button = $(this).children().first();
+        const button = $(`<button type="button" id="cod-toggle" class="ms-Button vc-discussion-comment-toolbarbutton ms-Button--icon"><i class="ms-Button-icon cod-toggle-icon bowtie-icon ${iconClass}" role="presentation"></i></button>`);
+        button.prependTo(this);
         button.attr('title', tooltip);
         button.click(async (event) => {
           const isNowFlagged = await toggleThreadFlaggedForCodeOfTheDay(getCurrentPullRequestUrl(), {

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -353,8 +353,8 @@
   function addCodeOfDayToggle() {
     async function commentThreadIsFlagged(threadId) {
       const flaggedThreads = await getCodeOfTheDayThreadsAsync();
-      const myFlaggedThreads = flaggedThreads.filter(x => x.flaggedBy === currentUser.displayName);
-      return myFlaggedThreads.find(x => x.threadId === threadId);
+      const myFlaggedThreads = flaggedThreads.filter((x) => x.flaggedBy === currentUser.displayName);
+      return myFlaggedThreads.find((x) => x.threadId === threadId);
     }
 
     function getThreadDataFromDOMElement(threadElement) {
@@ -601,7 +601,7 @@
             // If there is no owner info or if it returns zero files to review (since we may not be on the review explicitly), then count the number of files in the merge commit.
             if (fileCount === 0) {
               const mergeCommitInfo = await $.get(`${pr.lastMergeCommit.url}/changes?api-version=5.0`);
-              fileCount = _(mergeCommitInfo.changes).filter(item => !item.item.isFolder).size();
+              fileCount = _(mergeCommitInfo.changes).filter((item) => !item.item.isFolder).size();
             }
 
             const fileCountContent = `<span class="contributed-icon flex-noshrink fabric-icon ms-Icon--FileCode"></span>&nbsp;${fileCount}`;
@@ -658,7 +658,7 @@
 
   // Async helper function to sleep.
   function sleep(milliseconds) {
-    return new Promise(resolve => setTimeout(resolve, milliseconds));
+    return new Promise((resolve) => setTimeout(resolve, milliseconds));
   }
 
   // Async helper function to get a specific PR property, otherwise return the default value.
@@ -674,7 +674,7 @@
   // Async helper function to flag or unflag a PR discussion thread for "Code of the Day".
   async function toggleThreadFlaggedForCodeOfTheDay(prUrl, value) {
     function findIndexOf(toFind, flaggedCommentArray) {
-      for (var i = 0; i < flaggedCommentArray.length; i += 1) {
+      for (let i = 0; i < flaggedCommentArray.length; i += 1) {
         if (flaggedCommentArray[i].flaggedBy === toFind.flaggedBy
           && flaggedCommentArray[i].threadId === toFind.threadId) {
           return i;
@@ -728,7 +728,7 @@
 
   // Helper function to access an object member, where the exact, full name of the member is not known.
   function getPropertyNameStartingWith(instance, startOfName) {
-    return Object.getOwnPropertyNames(instance).find(x => x.startsWith(startOfName));
+    return Object.getOwnPropertyNames(instance).find((x) => x.startsWith(startOfName));
   }
 
   // Async helper function to return reviewer info specific to National Instruments workflows (where this script is used the most).
@@ -759,7 +759,7 @@
     };
 
     // See if the current user is listed in this PR.
-    const currentUserListedInThisOwnerReview = _(reviewProperties.reviewerIdentities).some(r => r.email === currentUser.uniqueName);
+    const currentUserListedInThisOwnerReview = _(reviewProperties.reviewerIdentities).some((r) => r.email === currentUser.uniqueName);
 
     // Go through all the files listed in the PR.
     if (currentUserListedInThisOwnerReview) {
@@ -767,7 +767,7 @@
         // Get the identities associated with each of the known roles.
         const owner = reviewProperties.reviewerIdentities[file.Owner - 1] || {};
         const alternate = reviewProperties.reviewerIdentities[file.Alternate - 1] || {}; // handle nulls everywhere
-        const reviewers = file.Reviewers.map(r => reviewProperties.reviewerIdentities[r - 1]) || [];
+        const reviewers = file.Reviewers.map((r) => reviewProperties.reviewerIdentities[r - 1]) || [];
 
         // Pick the highest role for the current user on this file, and track it.
         if (owner.email === currentUser.uniqueName) {
@@ -776,7 +776,7 @@
         } else if (alternate.email === currentUser.uniqueName) {
           ownersInfo.currentUserFilesToRole[file.Path] = 'A';
           ownersInfo.currentUserFileCount += 1;
-        } else if (_(reviewers).some(r => r.email === currentUser.uniqueName)) {
+        } else if (_(reviewers).some((r) => r.email === currentUser.uniqueName)) {
           ownersInfo.currentUserFilesToRole[file.Path] = 'R';
           ownersInfo.currentUserFileCount += 1;
         }

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -53,7 +53,9 @@
       makePullRequestDiffEasierToScroll();
       applyStickyPullRequestComments();
       addAccessKeysToPullRequestTabs();
-      await addCodeOfDayToggle();
+      if (/\/DevCentral\/_git\/ASW\//i.test(window.location.pathname)) {
+        await addCodeOfDayToggle();
+      }
     } else if (/\/(_pulls|pullrequests)/i.test(window.location.pathname)) {
       sortPullRequestDashboard();
     }

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -371,7 +371,7 @@
       const iconClass = isFlagged ? flaggedIconClass : notFlaggedIconClass;
       const tooltip = isFlagged ? flaggedTooltip : notFlaggedTooltip;
       $(this).find('.vc-discussion-comment-toolbar').each(function () {
-        const button = $(`<button type="button" id="cod-toggle" class="ms-Button vc-discussion-comment-toolbarbutton ms-Button--icon"><i class="ms-Button-icon cod-toggle-icon bowtie-icon ${iconClass}" role="presentation"></i></button>`);
+        const button = $(`<button type="button" class="ms-Button vc-discussion-comment-toolbarbutton ms-Button--icon cod-toggle"><i class="ms-Button-icon cod-toggle-icon bowtie-icon ${iconClass}" role="presentation"></i></button>`);
         button.prependTo(this);
         button.attr('title', tooltip);
         button.click(async (event) => {
@@ -385,7 +385,7 @@
             threadContentShort: truncate(thread.comments[0].content, 100),
           });
           // Update the button visuals in this thread
-          const buttons = $(this).parents('.vc-discussion-comments').find('#cod-toggle');
+          const buttons = $(this).parents('.vc-discussion-comments').find('.cod-toggle');
           buttons.attr('title', isNowFlagged ? flaggedTooltip : notFlaggedTooltip);
           const classToAdd = isNowFlagged ? flaggedIconClass : notFlaggedIconClass;
           const classToRemove = isNowFlagged ? notFlaggedIconClass : flaggedIconClass;

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -694,7 +694,7 @@
       await $.ajax({
         type: 'PATCH',
         url: `${prUrl}/properties?api-version=5.1-preview.1`,
-        data: patch,
+        data: JSON.stringify(patch),
         contentType: 'application/json-patch+json',
       });
     } catch (e) {

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -361,19 +361,22 @@
       return getPropertyThatStartsWith(threadElement, '__reactEventHandlers$').children[0].props.thread;
     }
 
+    function updateButtonForCurrentState(jqElements, isFlagged) {
+      const flaggedIconClass = 'bowtie-live-update-feed-off';
+      const notFlaggedIconClass = 'bowtie-live-update-feed';
+      const classToAdd = isFlagged ? flaggedIconClass : notFlaggedIconClass;
+      const classToRemove = isFlagged ? notFlaggedIconClass : flaggedIconClass;
+      jqElements.find('.cod-toggle-icon').addClass(classToAdd).removeClass(classToRemove);
+      jqElements.attr('title', isFlagged ? 'Un-suggest for "Code of the Day" blog post' : 'Suggest for "Code of the Day" blog post');
+    }
+
     $('.vc-discussion-comments').once('add-cod-flag-support').each(async function () {
       const thread = getThreadDataFromDOMElement(this);
-      const notFlaggedTooltip = 'Suggest for "Code of the Day" blog post';
-      const flaggedTooltip = 'Un-suggest for "Code of the Day" blog post';
-      const notFlaggedIconClass = 'bowtie-live-update-feed';
-      const flaggedIconClass = 'bowtie-live-update-feed-off';
       const isFlagged = await commentThreadIsFlagged(thread.id);
-      const iconClass = isFlagged ? flaggedIconClass : notFlaggedIconClass;
-      const tooltip = isFlagged ? flaggedTooltip : notFlaggedTooltip;
       $(this).find('.vc-discussion-comment-toolbar').each(function () {
-        const button = $(`<button type="button" class="ms-Button vc-discussion-comment-toolbarbutton ms-Button--icon cod-toggle"><i class="ms-Button-icon cod-toggle-icon bowtie-icon ${iconClass}" role="presentation"></i></button>`);
+        const button = $('<button type="button" class="ms-Button vc-discussion-comment-toolbarbutton ms-Button--icon cod-toggle"><i class="ms-Button-icon cod-toggle-icon bowtie-icon" role="presentation"></i></button>');
+        updateButtonForCurrentState(button, isFlagged);
         button.prependTo(this);
-        button.attr('title', tooltip);
         button.click(async (event) => {
           const isNowFlagged = await toggleThreadFlaggedForCodeOfTheDay(getCurrentPullRequestUrl(), {
             flaggedDate: new Date().toISOString(),
@@ -384,12 +387,9 @@
             threadAuthor: thread.comments[0].author.displayName,
             threadContentShort: truncate(thread.comments[0].content, 100),
           });
+
           // Update the button visuals in this thread
-          const buttons = $(this).parents('.vc-discussion-comments').find('.cod-toggle');
-          buttons.attr('title', isNowFlagged ? flaggedTooltip : notFlaggedTooltip);
-          const classToAdd = isNowFlagged ? flaggedIconClass : notFlaggedIconClass;
-          const classToRemove = isNowFlagged ? notFlaggedIconClass : flaggedIconClass;
-          buttons.find('.cod-toggle-icon').addClass(classToAdd).removeClass(classToRemove);
+          updateButtonForCurrentState($(this).parents('.vc-discussion-comments').find('.cod-toggle'), isNowFlagged);
         });
       });
     });

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -237,7 +237,7 @@
           $(this)
             .find('ul')
             .prepend('<li class="menu-item" role="button"><a href="#">Toggle other files</a></li>')
-            .click((event) => {
+            .click(event => {
               $('.files-container').toggleClass('hide-files-not-to-review');
             });
         });
@@ -353,8 +353,8 @@
   function addCodeOfDayToggle() {
     async function commentThreadIsFlagged(threadId) {
       const flaggedThreads = await getCodeOfTheDayThreadsAsync();
-      const myFlaggedThreads = flaggedThreads.filter((x) => x.flaggedBy === currentUser.displayName);
-      return myFlaggedThreads.find((x) => x.threadId === threadId);
+      const myFlaggedThreads = flaggedThreads.filter(x => x.flaggedBy === currentUser.displayName);
+      return myFlaggedThreads.find(x => x.threadId === threadId);
     }
 
     function getThreadDataFromDOMElement(threadElement) {
@@ -601,7 +601,7 @@
             // If there is no owner info or if it returns zero files to review (since we may not be on the review explicitly), then count the number of files in the merge commit.
             if (fileCount === 0) {
               const mergeCommitInfo = await $.get(`${pr.lastMergeCommit.url}/changes?api-version=5.0`);
-              fileCount = _(mergeCommitInfo.changes).filter((item) => !item.item.isFolder).size();
+              fileCount = _(mergeCommitInfo.changes).filter(item => !item.item.isFolder).size();
             }
 
             const fileCountContent = `<span class="contributed-icon flex-noshrink fabric-icon ms-Icon--FileCode"></span>&nbsp;${fileCount}`;
@@ -658,7 +658,7 @@
 
   // Async helper function to sleep.
   function sleep(milliseconds) {
-    return new Promise((resolve) => setTimeout(resolve, milliseconds));
+    return new Promise(resolve => setTimeout(resolve, milliseconds));
   }
 
   // Async helper function to get a specific PR property, otherwise return the default value.
@@ -728,7 +728,7 @@
 
   // Helper function to access an object member, where the exact, full name of the member is not known.
   function getPropertyNameStartingWith(instance, startOfName) {
-    return Object.getOwnPropertyNames(instance).find((x) => x.startsWith(startOfName));
+    return Object.getOwnPropertyNames(instance).find(x => x.startsWith(startOfName));
   }
 
   // Async helper function to return reviewer info specific to National Instruments workflows (where this script is used the most).
@@ -759,7 +759,7 @@
     };
 
     // See if the current user is listed in this PR.
-    const currentUserListedInThisOwnerReview = _(reviewProperties.reviewerIdentities).some((r) => r.email === currentUser.uniqueName);
+    const currentUserListedInThisOwnerReview = (reviewProperties.reviewerIdentities).some(r => r.email === currentUser.uniqueName);
 
     // Go through all the files listed in the PR.
     if (currentUserListedInThisOwnerReview) {
@@ -767,7 +767,7 @@
         // Get the identities associated with each of the known roles.
         const owner = reviewProperties.reviewerIdentities[file.Owner - 1] || {};
         const alternate = reviewProperties.reviewerIdentities[file.Alternate - 1] || {}; // handle nulls everywhere
-        const reviewers = file.Reviewers.map((r) => reviewProperties.reviewerIdentities[r - 1]) || [];
+        const reviewers = file.Reviewers.map(r => reviewProperties.reviewerIdentities[r - 1]) || [];
 
         // Pick the highest role for the current user on this file, and track it.
         if (owner.email === currentUser.uniqueName) {
@@ -776,7 +776,7 @@
         } else if (alternate.email === currentUser.uniqueName) {
           ownersInfo.currentUserFilesToRole[file.Path] = 'A';
           ownersInfo.currentUserFileCount += 1;
-        } else if (_(reviewers).some((r) => r.email === currentUser.uniqueName)) {
+        } else if (_(reviewers).some(r => r.email === currentUser.uniqueName)) {
           ownersInfo.currentUserFilesToRole[file.Path] = 'R';
           ownersInfo.currentUserFileCount += 1;
         }

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -672,13 +672,7 @@
   // Async helper function to flag or unflag a PR discussion thread for "Code of the Day".
   async function toggleThreadFlaggedForCodeOfTheDay(prUrl, value) {
     function findIndexOf(toFind, flaggedCommentArray) {
-      for (let i = 0; i < flaggedCommentArray.length; i += 1) {
-        if (flaggedCommentArray[i].flaggedBy === toFind.flaggedBy
-          && flaggedCommentArray[i].threadId === toFind.threadId) {
-          return i;
-        }
-      }
-      return -1;
+      return _.findIndex(flaggedCommentArray, x => x.threadId === toFind.threadId && x.flaggedBy === toFind.flaggedBy);
     }
 
     const flaggedComments = await getCodeOfTheDayThreadsAsync();

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -375,7 +375,7 @@
         const button = $(this).children().first();
         button.attr('title', tooltip);
         button.click(async (event) => {
-          const isNowFlagged = await toggleThreadFlaggedForCodeOfTheDay(getPullRequestUrl(), {
+          const isNowFlagged = await toggleThreadFlaggedForCodeOfTheDay(getCurrentPullRequestUrl(), {
             flaggedDate: new Date().toISOString(),
             flaggedBy: currentUser.displayName,
             pullRequestId: getCurrentPullRequestId(),
@@ -643,7 +643,7 @@
   }
 
   // Helper function to get the url of the PR that's on screen.
-  function getPullRequestUrl() {
+  function getCurrentPullRequestUrl() {
     const prDataProvider = pageData['ms.vss-code-web.pull-request-detail-data-provider'];
     return getPropertyThatStartsWith(prDataProvider, 'TFS.VersionControl.PullRequestDetailProvider.PullRequest.').url;
   }
@@ -718,7 +718,7 @@
     if (codeOfTheDayThreadsArray) {
       return codeOfTheDayThreadsArray;
     }
-    const properties = await $.get(`${getPullRequestUrl()}/properties?api-version=5.1-preview.1`);
+    const properties = await $.get(`${getCurrentPullRequestUrl()}/properties?api-version=5.1-preview.1`);
     const codeOfTheDayProperty = properties.value['NI.CodeOfTheDay'];
     codeOfTheDayThreadsArray = codeOfTheDayProperty ? JSON.parse(codeOfTheDayProperty.$value) : [];
     return codeOfTheDayThreadsArray;

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -709,12 +709,9 @@
 
   // Async helper function to get the discussion threads (in the current PR) that have been flagged for "Code of the Day."
   async function getCodeOfTheDayThreadsAsync() {
-    if (codeOfTheDayThreadsArray) {
-      return codeOfTheDayThreadsArray;
+    if (!codeOfTheDayThreadsArray) {
+      codeOfTheDayThreadsArray = await getPullRequestProperty(getCurrentPullRequestUrl(), 'NI.CodeOfTheDay', []);
     }
-    const properties = await $.get(`${getCurrentPullRequestUrl()}/properties?api-version=5.1-preview.1`);
-    const codeOfTheDayProperty = properties.value['NI.CodeOfTheDay'];
-    codeOfTheDayThreadsArray = codeOfTheDayProperty ? JSON.parse(codeOfTheDayProperty.$value) : [];
     return codeOfTheDayThreadsArray;
   }
 

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -325,7 +325,7 @@
       // Add an option for each iteration in the dropdown, looking roughly the same as the AzDO update selector.
       for (const iteration of iterations.reverse()) {
         const date = Date.parse(iteration.createdDate);
-        const truncatedDescription = iteration.description.length > 60 ? `${iteration.description.substring(0, 58)}...` : iteration.description;
+        const truncatedDescription = truncate(iteration.description);
         const optionText = `Update ${iteration.id.toString().padEnd(4)} ${truncatedDescription.padEnd(61)} ${dateFns.distanceInWordsToNow(date).padStart(15)} ago`;
         $('<option>').val(iteration.id).text(optionText).appendTo(selector);
       }
@@ -353,7 +353,7 @@
   function addCodeOfDayToggle() {
     async function commentThreadIsFlagged(threadId) {
       const flaggedThreads = await getCodeOfTheDayThreadsAsync();
-      const myFlaggedThreads = flaggedThreads.filter(x => x.flaggedBy === currentUser.displayName);
+      const myFlaggedThreads = flaggedThreads.filter(x => x.flaggedBy === currentUser.uniqueName);
       return myFlaggedThreads.find(x => x.threadId === threadId);
     }
 
@@ -377,12 +377,12 @@
         button.click(async (event) => {
           const isNowFlagged = await toggleThreadFlaggedForCodeOfTheDay(getCurrentPullRequestUrl(), {
             flaggedDate: new Date().toISOString(),
-            flaggedBy: currentUser.displayName,
+            flaggedBy: currentUser.uniqueName,
             pullRequestId: getCurrentPullRequestId(),
             threadId: thread.id,
             file: thread.itemPath,
             threadAuthor: thread.comments[0].author.displayName,
-            threadContentShort: thread.comments[0].content.length > 100 ? `${thread.comments[0].content.substring(0, 100)}...` : thread.comments[0].content,
+            threadContentShort: truncate(thread.comments[0].content, 100),
           });
           // Update the button visuals in this thread
           const buttons = $(this).parents('.vc-discussion-comments').find('#cod-toggle');
@@ -727,6 +727,11 @@
   // Helper function to access an object member, where the exact, full name of the member is not known.
   function getPropertyThatStartsWith(instance, startOfName) {
     return instance[Object.getOwnPropertyNames(instance).find(x => x.startsWith(startOfName))];
+  }
+
+  // Helper function to limit a string to a certain length, adding an ellipsis if necessary.
+  function truncate(text, maxLength) {
+    return text.length > maxLength ? `${text.substring(0, maxLength - 3)}...` : text;
   }
 
   // Async helper function to return reviewer info specific to National Instruments workflows (where this script is used the most).

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -378,7 +378,7 @@
           const isNowFlagged = await toggleThreadFlaggedForCodeOfTheDay(getPullRequestUrl(), {
             flaggedDate: new Date().toISOString(),
             flaggedBy: currentUser.displayName,
-            pullRequestId: getPullRequestId(),
+            pullRequestId: getCurrentPullRequestId(),
             threadId: thread.id,
             file: thread.itemPath,
             threadAuthor: thread.comments[0].author.displayName,
@@ -638,7 +638,7 @@
   }
 
   // Helper function to get the id of the PR that's on screen.
-  function getPullRequestId() {
+  function getCurrentPullRequestId() {
     return window.location.pathname.substring(window.location.pathname.lastIndexOf('/') + 1);
   }
 
@@ -650,7 +650,7 @@
 
   // Async helper function get info on a single PR. Defaults to the PR that's currently on screen.
   function getPullRequest(id = 0) {
-    const actualId = id || getPullRequestId();
+    const actualId = id || getCurrentPullRequestId();
     return $.get(`${azdoApiBaseUrl}/_apis/git/pullrequests/${actualId}?api-version=5.0`);
   }
 

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -375,7 +375,7 @@
             'threadId': thread.id,
             'file': thread.itemPath,
             'threadAuthor': thread.comments[0].author.displayName,
-            'threadContentShort': thread.comments[0].content.substring(0, 100) + '...'
+            'threadContentShort': thread.comments[0].content.length > 100 ? thread.comments[0].content.substring(0, 100) + '...' : thread.comments[0].content
           });
           // Update the button visuals in this thread
           $(this).parents('.vc-discussion-comments').find('.cod-toggle-icon').toggleClass('bowtie-comment-add').toggleClass('bowtie-comment-outline');

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -676,13 +676,13 @@
     }
 
     const flaggedComments = await getCodeOfTheDayThreadsAsync();
-    if (flaggedComments) {
-      const index = findIndexOf(value, flaggedComments);
-      if (index >= 0) {
-        flaggedComments.splice(index, 1);
-      } else {
-        flaggedComments.push(value);
-      }
+    const index = findIndexOf(value, flaggedComments);
+    if (index >= 0) {
+      // found, so unflag it
+      flaggedComments.splice(index, 1);
+    } else {
+      // not found, so flag it
+      flaggedComments.push(value);
     }
 
     const patch = [{

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -753,7 +753,7 @@
     };
 
     // See if the current user is listed in this PR.
-    const currentUserListedInThisOwnerReview = (reviewProperties.reviewerIdentities).some(r => r.email === currentUser.uniqueName);
+    const currentUserListedInThisOwnerReview = _(reviewProperties.reviewerIdentities).some(r => r.email === currentUser.uniqueName);
 
     // Go through all the files listed in the PR.
     if (currentUserListedInThisOwnerReview) {

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -694,8 +694,7 @@
       await $.ajax({
         type: 'PATCH',
         url: `${prUrl}/properties?api-version=5.1-preview.1`,
-        data: JSON.stringify(patch),
-        dataType: 'json',
+        data: patch,
         contentType: 'application/json-patch+json',
       });
     } catch (e) {


### PR DESCRIPTION
Cifra wanted to be able to flag a certain PR thread so that he could later write a "Code of the Day" blog post about it. To avoid embarrassing anyone, it has to be implemented in a way that it's not obvious when someone's PR/thread has been flagged.

I added a button next to the "like comment" button that toggles whether the thread is flagged (individual comments are not flagged). When a thread is flagged the button icon and the tooltip changes. You only see the flag statuses that _you_ have set. If other people flag a thread, you will not see it, and you can toggle your own flagged state for that thread independently.

The flagged thread states for a particular PR are persisted in a hidden property (NI.CodeOfTheDay) on that PR. These states will be fetched via a script. One limitation of this persistence approach is that completing a PR effectively "freezes" all COD flagging on it. You can't modify the properties on a completed PR.