### PR TITLE
Fix bug in "notable activity" logic

### DIFF
--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 
 // @name         AzDO Pull Request Improvements
-// @version      2.24.0
+// @version      2.25.0
 // @author       Alejandro Barreto (National Instruments)
 // @description  Adds sorting and categorization to the PR dashboard. Also adds minor improvements to the PR diff experience, such as a base update selector and per-file checkboxes.
 // @license      MIT

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -534,7 +534,7 @@
               }
 
               // See if this thread represents a non-approved vote.
-              if (Object.prototype.hasOwnProperty.call(thread, 'CodeReviewThreadType')) {
+              if (Object.prototype.hasOwnProperty.call(thread.properties, 'CodeReviewThreadType')) {
                 if (thread.properties.CodeReviewThreadType.$value === 'VoteUpdate') {
                   // Stop looking at threads once we find the thread that represents our vote.
                   const votingUser = thread.identities[thread.properties.CodeReviewVotedByIdentity.$value];


### PR DESCRIPTION
I stumbled on this bug by examination, not by noticing incorrect behavior. However, the symptoms would be:
1. Any thread in the PR with enough words or comments in it could trigger the "notable activity" categorization -- even those threads that happened before the user approved the PR.
2. The "notable activity" categorization never triggers based on other reviewers giving rejected/waiting votes.