### PR TITLE
Sort prs by added date

### DIFF
--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -488,7 +488,10 @@
 
           // Get non-deleted pr threads, ordered from newest to oldest.
           const prThreads = (await $.get(`${pr.url}/threads?api-version=5.0`)).value.filter(x => !x.isDeleted).reverse();
-          const userAddedTimestamp = getReviewerAddedOrResetTimestamp(prThreads, currentUser.uniqueName);
+          let userAddedTimestamp = getReviewerAddedOrResetTimestamp(prThreads, currentUser.uniqueName);
+          if (!userAddedTimestamp) {
+            userAddedTimestamp = pr.creationDate;
+          }
 
           // Order the reviews by when the current user was added (reviews that the user was added to most recently are listed last). We do this by ordering the rows inside a reversed-order flex container.
           // The order property is a 32-bit integer. If treat it as number of seconds, that allows a range of 68 years (2147483647 / (60 * 60 * 24 * 365)) in the positive values alone.

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 
 // @name         AzDO Pull Request Improvements
-// @version      2.25.0
+// @version      2.26.0
 // @author       Alejandro Barreto (National Instruments)
 // @description  Adds sorting and categorization to the PR dashboard. Also adds minor improvements to the PR diff experience, such as a base update selector and per-file checkboxes.
 // @license      MIT


### PR DESCRIPTION
Before separating PR dashboard rows into different buckets (e.g. Drafts, Approved, etc), set their relative order based on when the user was (most recently) added to the review.

The most direct way I know of to get that information is by looking for the comment thread that announces when a reviewer is added to the PR. We were already querying the threads for PRs that the user had approved (in order to check for "notable activity"), but now we have to do this for all PRs the user is on. That will result in a performance hit, but it should be acceptable.