### PR TITLE
npm script for fixing eslint issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "build": "npm run lint",
-    "lint": "eslint --ignore-path .gitignore ."
+    "lint": "eslint --ignore-path .gitignore .",
+    "lint-fix": "eslint --fix --ignore-path .gitignore ."
   }
 }


### PR DESCRIPTION
On my last PR I had a bunch of eslint errors that could all be fixed by eslint itself.  To make it easier to run eslint in this mode, I added an npm script to do this.

Tested on my last PR to fix the second round of eslint errors.