### PR TITLE
Bigger dropdowns and less prominent work item prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ After :smirk:
 
 ![Scrollbars now.](assets/scrollbars-after.png)
 
+Also:
+
+- Drop down menus are bigger!
+- Prompts to add links to work items are much less prominent, unless hovered over
+
 ## Documentation
 
 - [Support and troubleshooting](SUPPORT.md)

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -124,7 +124,7 @@
       .identity-picker-dropdown ul.items, .scroll-tree-overflow-box, .ui-autocomplete, .vss-PickList--items {
         max-height: 50vh !important;
       }
-      /* Make annoying prompts to add links to work items less prominent, unless hovered over */
+      /* Prompts to add links to work items are much less prominent, unless hovered over */
       .zero-data-action, .deployments-zero-data {
         opacity: 0.2;
       }

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 
 // @name         AzDO Pull Request Improvements
-// @version      2.33.0
+// @version      2.34.0
 // @author       Alejandro Barreto (National Instruments)
 // @description  Adds sorting and categorization to the PR dashboard. Also adds minor improvements to the PR diff experience, such as a base update selector and per-file checkboxes.
 // @license      MIT
@@ -61,7 +61,7 @@
       enhancePullRequestDashboard();
     }
 
-    applyNicerScrollbars();
+    enhanceOverallUX();
   }
 
   function highlightAwaitComments() {
@@ -107,8 +107,9 @@
     });
   }
 
-  function applyNicerScrollbars() {
-    addStyleOnce('nicer-scrollbars', /* css */ `
+  function enhanceOverallUX() {
+    addStyleOnce('enhance-overall-ux', /* css */ `
+      /* Colored scrollbars */
       ::-webkit-scrollbar {
         width: 15px;
         height: 15px;
@@ -118,6 +119,21 @@
       }
       ::-webkit-scrollbar-thumb {
         background: rgb(var(--palette-neutral-20));
+      }
+      /* Bigger dropdown menus */
+      .identity-picker-dropdown ul.items, .scroll-tree-overflow-box, .ui-autocomplete, .vss-PickList--items {
+        max-height: 50vh !important;
+      }
+      /* Make annoying prompts to add links to work items less prominent, unless hovered over */
+      .zero-data-action, .deployments-zero-data {
+        opacity: 0.2;
+      }
+      .zero-data-action img, .deployments-zero-data img,
+      .zero-data-action i, .deployments-zero-data i {
+        display: none;
+      }
+      .zero-data-action:hover, .deployments-zero-data:hover {
+        opacity: 1;
       }`);
   }
 


### PR DESCRIPTION
- Dropdowns now grow to up to 50% of screen height, instead of being locked to a fixed size
- Prompts to add links to work items are noisy and annoying. Made them less so 