### PR TITLE
Color known labels and add labels to overall PR dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ Also, build status on PRs (see right column)! If it's empty, there isn't a build
 
 ![Build status on PRs](assets/build-status.png)
 
+More:
+
+- Labels now appear on the overall PR dashboard
+- At NI, some labels get coloring (e.g. "bypass owners" gets a red background)
+
 ### PR diff improvements
 
 You can now mark a file as reviewed with a checkbox! The data persists in local browser storage, so if you come back to the PR later, the checkboxes will still be there (up to 3 weeks).

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 
 // @name         AzDO Pull Request Improvements
-// @version      2.36.1
+// @version      2.37.0
 // @author       Alejandro Barreto (National Instruments)
 // @description  Adds sorting and categorization to the PR dashboard. Also adds minor improvements to the PR diff experience, such as a base update selector and per-file checkboxes.
 // @license      MIT

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -89,7 +89,7 @@
     /* The overall PR dashboard doesn't show tags by default, so we need to add in some CSS when we add tags to that dashboard. */
     .prlist .tag-box {
       margin: 2px 3px;
-      padding: 2px 6px;
+      padding: 0px 6px;
       font-size: 12px;
       color: rgba(0,0,0,.55);
       color: var(--text-secondary-color,rgba(0, 0, 0, .55));


### PR DESCRIPTION
This feature only works at NI.

Note: The overall PR dashboard didn't have labels; now it does.