### PR TITLE
Avoid null entries in reviewer array

### DIFF
--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1097,6 +1097,7 @@
     if (currentUserListedInThisOwnerReview) {
       for (const file of reviewProperties.fileProperties) {
         // Get the identities associated with each of the known roles.
+        // Note that the values for file.owner/alternate/reviewers may contain the value 0 (which is not a valid 1-based index) to indicate nobody for that role.
         const owner = reviewProperties.reviewerIdentities[file.owner - 1] || {};
         const alternate = reviewProperties.reviewerIdentities[file.alternate - 1] || {}; // handle nulls everywhere
         const reviewers = file.reviewers.map(r => reviewProperties.reviewerIdentities[r - 1] || {}) || [];

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 
 // @name         AzDO Pull Request Improvements
-// @version      2.41.2
+// @version      2.41.3
 // @author       Alejandro Barreto (National Instruments)
 // @description  Adds sorting and categorization to the PR dashboard. Also adds minor improvements to the PR diff experience, such as a base update selector and per-file checkboxes.
 // @license      MIT
@@ -1099,7 +1099,7 @@
         // Get the identities associated with each of the known roles.
         const owner = reviewProperties.reviewerIdentities[file.owner - 1] || {};
         const alternate = reviewProperties.reviewerIdentities[file.alternate - 1] || {}; // handle nulls everywhere
-        const reviewers = file.reviewers.map(r => reviewProperties.reviewerIdentities[r - 1]) || [];
+        const reviewers = file.reviewers.map(r => reviewProperties.reviewerIdentities[r - 1] || {}) || [];
 
         // Pick the highest role for the current user on this file, and track it.
         if (owner.email === currentUser.uniqueName) {


### PR DESCRIPTION
The "some" call was trying to access the "email" property on each item in the reviewers array. During the decompression of identities, this could have gotten null entries, rather than blank objects (as we do with "owner" and "alternate"). To avoid a null deref error, we also need to map 0 indices into blank objects for the reviewers.