### PR TITLE
Add suggestion to bypass owners that pops up when hovering on Approve

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ PR comments that start with `await:` (case insensitive) will appear highlighted.
 
 ![Await comments are highlighted.](assets/await-comments.png)
 
+### Bypass owners reminder
+
+For PRs into branches requiring a passing ni/owners-approved status, hovering over the Approve button pops up a reminder to consider bypassing owners.
+
 ### PR trophies
 
 Trophies are awarded for notable PRs and shown in a trophies section on the Overview tab. For example:

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -171,7 +171,9 @@
     }
     .label--bypassowners {
       background: #a008 !important;
-    }
+    }`);
+
+  addStyleOnce('bypassOwnersPrompt', /* css */ `
     .bypass-reminder {
       display: none;
       position: absolute;
@@ -309,6 +311,11 @@
       return;
     }
 
+    if (!$(document.body).once('add-bypass-banner')) {
+      return;
+    }
+
+    // This has to be a paragraph so that the bypass reminder div has an anchor ("origin" of the absolute position) other than the upper left corner of the whole page.
     const container = document.createElement('p');
     container.classList.add('bypass-reminder-container');
 
@@ -319,21 +326,20 @@
     if ($('.repos-pr-header-vote-button').length === 0) {
       // "old" PR experience
       $('#pull-request-vote-button')
-        .once('add-bypass-banner')
         .parent()
         .parent()
         .addClass('vote-button-wrapper')
         .appendTo(container);
       container.appendChild(banner);
-      $('.vote-control-container').once('add-bypass-banner').append(container);
+      $('.vote-control-container').append(container);
     } else {
       // "new" PR experience
       const buttonWrapper = document.createElement('div');
       buttonWrapper.classList.add('vote-button-wrapper');
-      $('.repos-pr-header-vote-button').once('add-bypass-banner').appendTo(buttonWrapper);
+      $('.repos-pr-header-vote-button').appendTo(buttonWrapper);
       container.appendChild(buttonWrapper);
       container.appendChild(banner);
-      $(container).insertBefore($('.repos-pr-header-complete-button').once('add-bypass-banner'));
+      $(container).insertBefore($('.repos-pr-header-complete-button'));
     }
   }
 

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -176,7 +176,7 @@
       display: none;
       position: absolute;
       top: 38px;
-      left: -230px;
+      left: -240px;
       z-index: 1000;
       background-color: #E6B307;
       padding: 8px 12px;

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -99,6 +99,9 @@
         applyStickyPullRequestComments();
         highlightAwaitComments();
         addAccessKeysToPullRequestTabs();
+        if (atNI) {
+          conditionallyAddBypassReminderAsync();
+        }
         addTrophiesToPullRequest();
         if (atNI && /\/DevCentral\/_git\/ASW\//i.test(window.location.pathname)) {
           addNICodeOfDayToggle();
@@ -168,6 +171,32 @@
     }
     .label--bypassowners {
       background: #a008 !important;
+    }
+    .bypass-reminder {
+      display: none;
+      position: absolute;
+      top: 38px;
+      left: -230px;
+      z-index: 1000;
+      background-color: #E6B307;
+      padding: 8px 12px;
+      border-radius: 8px;
+      box-shadow: 4px 4px 4px #18181888;
+    }
+    .bypass-reminder-container {
+      position: relative;
+      display: inline-flex;
+      flex-direction: column;
+    }
+    .vote-button-wrapper {
+      border: 3px solid transparent;
+      border-radius: 4px;
+    }
+    .vote-button-wrapper:hover {
+      border-color: #E6B307;
+    }
+    .vote-button-wrapper:hover ~ .bypass-reminder {
+      display: inline;
     }`);
 
   function styleLabels() {
@@ -271,6 +300,41 @@
       .zero-data-action:hover, .deployments-zero-data:hover {
         opacity: 1;
       }`);
+  }
+
+  // Adds a bypass suggestion message that pops up when the user mouses over the Approve button.
+  async function conditionallyAddBypassReminderAsync() {
+    // Only add it if the target branch requires owner approval
+    if (!(await pullRequestHasRequiredOwnersPolicyAsync())) {
+      return;
+    }
+
+    const container = document.createElement('p');
+    container.classList.add('bypass-reminder-container');
+
+    const banner = document.createElement('div');
+    banner.classList.add('bypass-reminder');
+    banner.appendChild(document.createTextNode('If you vouch for the whole PR, please bypass owners.'));
+
+    if ($('.repos-pr-header-vote-button').length === 0) {
+      // "old" PR experience
+      $('#pull-request-vote-button')
+        .once('add-bypass-banner')
+        .parent()
+        .parent()
+        .addClass('vote-button-wrapper')
+        .appendTo(container);
+      container.appendChild(banner);
+      $('.vote-control-container').once('add-bypass-banner').append(container);
+    } else {
+      // "new" PR experience
+      const buttonWrapper = document.createElement('div');
+      buttonWrapper.classList.add('vote-button-wrapper');
+      $('.repos-pr-header-vote-button').once('add-bypass-banner').appendTo(buttonWrapper);
+      container.appendChild(buttonWrapper);
+      container.appendChild(banner);
+      $(container).insertBefore($('.repos-pr-header-complete-button').once('add-bypass-banner'));
+    }
   }
 
   // Adds a "Trophies" section to the Overview tab of a PR for a qualifying PR number
@@ -1034,14 +1098,19 @@
     return window.location.pathname.substring(window.location.pathname.lastIndexOf('/') + 1);
   }
 
+  // Don't access this directly -- use getCurrentPullRequestAsync() instead.
   let currentPullRequest = null;
 
-  // Helper function to get the url of the PR that's currently on screen.
-  async function getCurrentPullRequestUrlAsync() {
+  async function getCurrentPullRequestAsync() {
     if (!currentPullRequest || currentPullRequest.pullRequestId !== getCurrentPullRequestId()) {
       currentPullRequest = await getPullRequestAsync();
     }
-    return currentPullRequest.url;
+    return currentPullRequest;
+  }
+
+  // Helper function to get the url of the PR that's currently on screen.
+  async function getCurrentPullRequestUrlAsync() {
+    return (await getCurrentPullRequestAsync()).url;
   }
 
   // Async helper function get info on a single PR. Defaults to the PR that's currently on screen.
@@ -1060,6 +1129,12 @@
     const properties = await $.get(`${prUrl}/properties?api-version=5.1-preview.1`);
     const property = properties.value[key];
     return property ? JSON.parse(property.$value) : defaultValue;
+  }
+
+  async function pullRequestHasRequiredOwnersPolicyAsync() {
+    const pr = await getCurrentPullRequestAsync();
+    const url = `${azdoApiBaseUrl}${pr.repository.project.name}/_apis/git/policy/configurations?repositoryId=${pr.repository.id}&refName=${pr.targetRefName}`;
+    return (await $.get(url)).value.some(x => x.isBlocking && x.settings.statusName === 'owners-approved');
   }
 
   // Cached "Code of the Day" thread data.

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 
 // @name         AzDO Pull Request Improvements
-// @version      2.42.0
+// @version      2.43.0
 // @author       Alejandro Barreto (National Instruments)
 // @description  Adds sorting and categorization to the PR dashboard. Also adds minor improvements to the PR diff experience, such as a base update selector and per-file checkboxes.
 // @license      MIT


### PR DESCRIPTION
We suspect that "Bypass Owners" is being under-used. We may be able to increase the use of this feature (and thereby increase PR throughput) just by reminding reviewers of it.

This PR adds a tooltip-like reminder that pops up when the user hovers over the Approve button. Many different approaches were considered, but this was the simplest while still seeming effective. This reminder is only installed for PRs that are targeted to a branch where the owners-approved policy is enforced. Thus it will not appear for non-NI repos, or for PRs into dev branches, for example.

I tested on both light and dark themes, and in both the "old" and "new" PR experiences.