### PR TITLE
Auto-click show more buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Also:
 
 - Drop down menus are bigger!
 - Prompts to add links to work items are much less prominent, unless hovered over
+- "Show More" buttons on work item forms and on Kanban boards are auto-clicked for you!
 
 ## Documentation
 

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -211,7 +211,7 @@
   }
 
   function watchForShowMoreButtons() {
-    // Press Show More buttons on work item forms, until they disappear or until we've pressed it 10 times (a reasonable limit which will still bring in 60 more items into view).
+    // Auto-click Show More buttons on work item forms, until they disappear or until we've pressed it 10 times (a reasonable limit which will still bring in 60 more items into view).
     eus.globalSession.onEveryNew(document, 'div[role="button"].la-show-more', async showMoreButton => {
       if (eus.seen(showMoreButton)) return;
 
@@ -227,11 +227,24 @@
       }
     });
 
-    // Press Show More buttons on Kanban boards.
-    // Note: Since there's no way to know how many times to press this (the link doesn't go away if there aren't any more), we will only press it once. This loads many more work items that it's unlikely you will see another Show More button unless your backlog is HUGE (in which case, loading all of them may make your UI very slow, so pressing it again is undesirable).
-    eus.globalSession.onEveryNew(document, 'a[role="button"].see-more-items', showMoreButton => {
+    // Auto-click Show More buttons on Kanban boards, until they disappear, are hidden, or until we've pressed it 5 times (a reasonable limit which will still bring in hundreds of items into view).
+    eus.globalSession.onEveryNew(document, 'a[role="button"].see-more-items', async showMoreButton => {
       if (eus.seen(showMoreButton)) return;
-      showMoreButton.click();
+
+      const container = showMoreButton.closest('.page-items-container');
+      let clicks = 0;
+
+      while (document.body.contains(showMoreButton) && container.style.display !== 'none') {
+        if (showMoreButton.style.display !== 'none') {
+          showMoreButton.click();
+
+          clicks += 1;
+          if (clicks >= 5) break;
+        }
+
+        // eslint-disable-next-line no-await-in-loop
+        await sleep(1000);
+      }
     });
   }
 

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -212,10 +212,14 @@
 
   function watchForShowMoreButtons() {
     // Press all show more buttons in work item forms, until they disappear.
-    eus.globalSession.onEveryNew(document, 'div[role="button"].la-show-more, a[role="button"].see-more-items', showMoreButton => {
+    eus.globalSession.onEveryNew(document, 'div[role="button"].la-show-more', async showMoreButton => {
       if (eus.seen(showMoreButton)) return;
+
       while (document.body.contains(showMoreButton)) {
         showMoreButton.click();
+
+        // eslint-disable-next-line no-await-in-loop
+        await sleep(100);
       }
     });
 

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -211,19 +211,24 @@
   }
 
   function watchForShowMoreButtons() {
-    // Press all show more buttons in work item forms, until they disappear.
+    // Press Show More buttons on work item forms, until they disappear or until we've pressed it 10 times (a reasonable limit which will still bring in 60 more items into view).
     eus.globalSession.onEveryNew(document, 'div[role="button"].la-show-more', async showMoreButton => {
       if (eus.seen(showMoreButton)) return;
 
+      let clicks = 0;
       while (document.body.contains(showMoreButton)) {
         showMoreButton.click();
+
+        clicks += 1;
+        if (clicks >= 10) break;
 
         // eslint-disable-next-line no-await-in-loop
         await sleep(100);
       }
     });
 
-    // Press the Show More button on Kanban boards. Note: Since there's no way to know how many times to press this (the link doesn't go away if there aren't any more), we will only press it once.
+    // Press Show More buttons on Kanban boards.
+    // Note: Since there's no way to know how many times to press this (the link doesn't go away if there aren't any more), we will only press it once. This loads many more work items that it's unlikely you will see another Show More button unless your backlog is HUGE (in which case, loading all of them may make your UI very slow, so pressing it again is undesirable).
     eus.globalSession.onEveryNew(document, 'a[role="button"].see-more-items', showMoreButton => {
       if (eus.seen(showMoreButton)) return;
       showMoreButton.click();

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 
 // @name         AzDO Pull Request Improvements
-// @version      2.47.2
+// @version      2.48.0
 // @author       Alejandro Barreto (National Instruments)
 // @description  Adds sorting and categorization to the PR dashboard. Also adds minor improvements to the PR diff experience, such as a base update selector and per-file checkboxes.
 // @license      MIT
@@ -64,6 +64,7 @@
     watchPullRequestDashboard();
     watchForNewLabels();
     watchForNewDiffs(isDarkTheme);
+    watchForShowMoreButtons();
 
     // Handle any existing elements, flushing it to execute immediately.
     onPageUpdatedThrottled();
@@ -206,6 +207,14 @@
       if (!label.ariaLabel) return;
       const subClass = stringToCssIdentifier(label.ariaLabel);
       label.classList.add(`label--${subClass}`);
+    });
+  }
+
+  function watchForShowMoreButtons() {
+    // Press all show more buttons in work item forms and Kanban boards.
+    eus.globalSession.onEveryNew(document, 'div[role="button"].la-show-more, a[role="button"].see-more-items', showMoreButton => {
+      if (eus.seen(showMoreButton)) return;
+      showMoreButton.click();
     });
   }
 

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -211,8 +211,16 @@
   }
 
   function watchForShowMoreButtons() {
-    // Press all show more buttons in work item forms and Kanban boards.
+    // Press all show more buttons in work item forms, until they disappear.
     eus.globalSession.onEveryNew(document, 'div[role="button"].la-show-more, a[role="button"].see-more-items', showMoreButton => {
+      if (eus.seen(showMoreButton)) return;
+      while (document.body.contains(showMoreButton)) {
+        showMoreButton.click();
+      }
+    });
+
+    // Press the Show More button on Kanban boards. Note: Since there's no way to know how many times to press this (the link doesn't go away if there aren't any more), we will only press it once.
+    eus.globalSession.onEveryNew(document, 'a[role="button"].see-more-items', showMoreButton => {
       if (eus.seen(showMoreButton)) return;
       showMoreButton.click();
     });


### PR DESCRIPTION
It's annoying that AzDO does not load all work items when looking at a work item with many children, or looking at a Kanban board with more than 100 items (I think that's the limit?).

Now, the userscript will auto-click these buttons when they exist. That way, the UI will show all the work items that can be listed ❤️