### PR TITLE
Revert "Auto-click show more buttons (#109)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ Also:
 
 - Drop down menus are bigger!
 - Prompts to add links to work items are much less prominent, unless hovered over
-- "Show More" buttons on work item forms and on Kanban boards are auto-clicked for you!
 - Work item forms show under the comment box who else is following the work item
 
 ## Documentation

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 
 // @name         AzDO Pull Request Improvements
-// @version      2.49.0
+// @version      2.49.1
 // @author       Alejandro Barreto (National Instruments)
 // @description  Adds sorting and categorization to the PR dashboard. Also adds minor improvements to the PR diff experience, such as a base update selector and per-file checkboxes.
 // @license      MIT
@@ -65,7 +65,6 @@
     watchForNewLabels();
     watchForWorkItemForms();
     watchForNewDiffs(isDarkTheme);
-    watchForShowMoreButtons();
 
     // Handle any existing elements, flushing it to execute immediately.
     onPageUpdatedThrottled();
@@ -252,44 +251,6 @@
 
   function workItemSubscriptionFollowsEverything(subscription) {
     return subscription.description.startsWith("Following 'WorkItem' artifact");
-  }
-
-  function watchForShowMoreButtons() {
-    // Auto-click Show More buttons on work item forms, until they disappear or until we've pressed it 10 times (a reasonable limit which will still bring in 60 more items into view).
-    eus.globalSession.onEveryNew(document, 'div[role="button"].la-show-more', async showMoreButton => {
-      if (eus.seen(showMoreButton)) return;
-
-      let clicks = 0;
-      while (document.body.contains(showMoreButton)) {
-        showMoreButton.click();
-
-        clicks += 1;
-        if (clicks >= 10) break;
-
-        // eslint-disable-next-line no-await-in-loop
-        await sleep(100);
-      }
-    });
-
-    // Auto-click Show More buttons on Kanban boards, until they disappear, are hidden, or until we've pressed it 5 times (a reasonable limit which will still bring in hundreds of items into view).
-    eus.globalSession.onEveryNew(document, 'a[role="button"].see-more-items', async showMoreButton => {
-      if (eus.seen(showMoreButton)) return;
-
-      const container = showMoreButton.closest('.page-items-container');
-      let clicks = 0;
-
-      while (document.body.contains(showMoreButton) && container.style.display !== 'none') {
-        if (showMoreButton.style.display !== 'none') {
-          showMoreButton.click();
-
-          clicks += 1;
-          if (clicks >= 5) break;
-        }
-
-        // eslint-disable-next-line no-await-in-loop
-        await sleep(1000);
-      }
-    });
   }
 
   function stringToCssIdentifier(text) {


### PR DESCRIPTION
This reverts commit 2fd2cc460a714acd12cf8d6b866f711e1fa55917.

I've been recently having my New column forcibly expand itself even after I've closed it multiple times following an AzDO Boards page refresh. This hangs up my Boards refresh for up to a couple of minutes at a time. Additionally, this massively balloons (>4x) the number of filter options to look through, since those options are populated by the union of all currently visible work items.
 
While this seems like it could be helpful if these columns are in use, my squad only uses the New state for things outside our current iteration, so I always want the column collapsed when I'm using the Boards view. Revert for now, since this is having negative impact.

I included a third-digit version bump, since that seemed like the appropriate thing to do.