### PR TITLE
Add Code Snippet Support for Yammer

### DIFF
--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -711,13 +711,14 @@
 
       const match = paragraph.innerText.match(/^```(.*)/);
       if (match) {
-        [, language] = match;
+        let [, matchedLanguage] = match;
         // If no language was specified, just use `sh` as a default
-        if (!snippetStarted && !language) {
-          language = 'sh';
+        if (!snippetStarted && !matchedLanguage) {
+          matchedLanguage = 'sh';
         }
-        if (language) {
+        if (matchedLanguage) {
           snippetStarted = true;
+          language = matchedLanguage;
         } else {
           snippetStarted = false;
           wrapSnippetParagraphs(snippetParagraphs, paragraph, language, languageDefinitions);


### PR DESCRIPTION
# Details

Yammer currently does not support code snippets, which makes it hard for developers to communicate successfully.

azdo-userscripts is probably not the best place to add this functionality (because it is supposed to be for azdo-related features only), but it is such an easy-to-implement feature on top of it, that it may not be such a bad idea to extend it even outside of AzDO.

# Usage
Use the same markdown syntax to define a code snippet
![image](https://user-images.githubusercontent.com/8660999/95144928-8293f200-073f-11eb-9743-539bd2ca015d.png)

# Example

## Before
![image](https://user-images.githubusercontent.com/8660999/95144377-22e91700-073e-11eb-9415-58d14436e114.png)

## After
![image](https://user-images.githubusercontent.com/8660999/95144394-2da3ac00-073e-11eb-917f-c2a5bb20de50.png)

### Long replies:
![image](https://user-images.githubusercontent.com/8660999/95144440-4ad87a80-073e-11eb-84ac-e3e0131b5e84.png)
![image](https://user-images.githubusercontent.com/8660999/95144428-4613c680-073e-11eb-8ee0-0a03646f4e4f.png)

### Wrap text:
![image](https://user-images.githubusercontent.com/8660999/95210447-2073d500-07b1-11eb-9a34-1a46f2df7816.png)

