### PR TITLE
Fix to follower list not showing others

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Also:
 - Drop down menus are bigger!
 - Prompts to add links to work items are much less prominent, unless hovered over
 - "Show More" buttons on work item forms and on Kanban boards are auto-clicked for you! (But only if the New column is expanded.)
-- Work item forms show under the comment box who else is following the work item
+- Work item forms show under the comment box who else is following the work item (disclaimer: also shows people that are only following state changes)
 
 ## Documentation
 

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 
 // @name         AzDO Pull Request Improvements
-// @version      2.49.1
+// @version      2.49.2
 // @author       Alejandro Barreto (National Instruments)
 // @description  Adds sorting and categorization to the PR dashboard. Also adds minor improvements to the PR diff experience, such as a base update selector and per-file checkboxes.
 // @license      MIT
@@ -231,27 +231,19 @@
               },
             },
           ],
+          queryFlags: 'alwaysReturnBasicInformation',
         }),
       });
 
       const followers = [...(await queryResponse.json()).value].sort((a, b) => a.subscriber.displayName.localeCompare(b.subscriber.displayName));
-
-      const commentFollowers = followers
-        .filter(workItemSubscriptionFollowsEverything)
+      const followerList = followers
         .map(s => `<a href="mailto:${s.subscriber.uniqueName}">${s.subscriber.displayName}</a>`)
         .join(', ')
         || 'Nobody';
 
-      const fieldFollowerCount = followers.filter(s => !workItemSubscriptionFollowsEverything(s)).length;
-      const fieldFollowers = fieldFollowerCount ? `(and ${fieldFollowerCount} field follower${fieldFollowerCount > 1 ? 's' : ''})` : '';
-
-      const annotation = `<div style="margin: 1em 0em; opacity: 0.8"><span class="menu-item-icon bowtie-icon bowtie-watch-eye-fill" aria-hidden="true"></span> ${commentFollowers} ${fieldFollowers}</div>`;
+      const annotation = `<div style="margin: 1em 0em; opacity: 0.8"><span class="menu-item-icon bowtie-icon bowtie-watch-eye-fill" aria-hidden="true"></span> ${followerList}</div>`;
       commentEditor.insertAdjacentHTML('BeforeEnd', annotation);
     });
-  }
-
-  function workItemSubscriptionFollowsEverything(subscription) {
-    return subscription.description.startsWith("Following 'WorkItem' artifact");
   }
 
   function watchForShowMoreButtons() {


### PR DESCRIPTION
As it turns out, follower lists are private info to each user. Because of that, the follower listing on work items was only ever showing you, and not others -- well unless you were a super user (like me on the NI account).

To get around this, we need to perform the subscription query with the `alwaysReturnBasicInformation` query flag. This returns limited info on a subscription.

The limited info means we can't tell if the user is following the full work item or just state changes. But that's an acceptable limitation. We'll still list them in the follower list.

Fixes #123