### PR TITLE
Fix PR trophies

### DIFF
--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 
 // @name         AzDO Pull Request Improvements
-// @version      2.49.3
+// @version      2.49.4
 // @author       Alejandro Barreto (National Instruments)
 // @description  Adds sorting and categorization to the PR dashboard. Also adds minor improvements to the PR diff experience, such as a base update selector and per-file checkboxes.
 // @license      MIT

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -442,7 +442,7 @@
   // Adds a "Trophies" section to the Overview tab of a PR for a qualifying PR number
   function addTrophiesToPullRequest() {
     // Pull request author is sometimes undefined on first call. Only add trophies if we can get the author name.
-    const pullRequestAuthor = $('div.ms-TooltipHost.host_e6f6b93f.created-by-label').children('span').text();
+    const pullRequestAuthor = $('div.vc-pullrequest-created-by-section.row-group').children('div.ms-TooltipHost').children('span').text();
 
     // Only create the trophies section once.
     if ($('#trophies-section').length === 0 && pullRequestAuthor.length !== 0) {


### PR DESCRIPTION
The script code was looking for the PR author's name under `div.ms-TooltipHost.host_e6f6b93f.created-by-label`. The number after `host_` has changed, so the script could not find the author name and would not add the trophies section to the PR page.

Changed the code to get the PR author name by using the layer above the `ms-TooltipHost` instead. This should be less brittle.