### PR TITLE
Reimplement files tree highlighting for new PR experience

### DIFF
--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -69,6 +69,10 @@
     watchForNewDiffs(isDarkTheme);
     watchForShowMoreButtons();
 
+    if (atNI) {
+      watchFilesTree();
+    }
+
     // Handle any existing elements, flushing it to execute immediately.
     onPageUpdatedThrottled();
     onPageUpdatedThrottled.flush();
@@ -88,7 +92,6 @@
         highlightAwaitComments();
         addAccessKeysToPullRequestTabs();
         if (atNI) {
-          addOwnersInfoToFiles();
           conditionallyAddBypassReminderAsync();
           addNIBinaryDiffButton();
         }
@@ -589,157 +592,6 @@
       }`);
   }
 
-  // The func we'll call to continuously add checkboxes to the PR file listing, once initialization is over.
-  let annotateFilesTreeFunc = () => { };
-
-  // If we're on specific PR, add checkboxes to the file listing.
-  function addOwnersInfoToFiles() {
-    $('.vc-pullrequest-leftpane-section.files-tab').once('annotate-with-owners-info').each(async () => {
-      annotateFilesTreeFunc = () => { };
-
-      addStyleOnce('pr-file-tree-annotations-css', /* css */ `
-        :root {
-          /* Set some constants for our CSS. */
-          --file-to-review-color: var(--communication-foreground);
-        }
-        .vc-sparse-files-tree .tree-row.file-to-review-row,
-        .vc-sparse-files-tree .tree-row.file-to-review-row .file-name {
-          /* Highlight files I need to review. */
-          color: var(--file-to-review-color);
-          transition-duration: 0.2s;
-        }
-        .vc-sparse-files-tree .tree-row.folder-to-review-row[aria-expanded='false'],
-        .vc-sparse-files-tree .tree-row.folder-to-review-row[aria-expanded='false'] .file-name {
-          /* Highlight folders that have files I need to review, but only when files are hidden cause the folder is collapsed. */
-          color: var(--file-to-review-color);
-          transition-duration: 0.2s;
-        }
-        .vc-sparse-files-tree .tree-row.file-to-review-row .file-owners-role {
-          /* Style the role of the user in the files table. */
-          font-weight: bold;
-          padding: 7px 10px;
-          position: absolute;
-          z-index: 100;
-          float: right;
-        }
-        .file-to-review-diff {
-          /* Highlight files I need to review. */
-          border-left: 3px solid var(--file-to-review-color) !important;
-          padding-left: 7px;
-        }
-        .files-container.hide-files-not-to-review .file-container:not(.file-to-review-diff) {
-          /* Fade the header for files I don't have to review. */
-          opacity: 0.2;
-        }
-        .files-container.hide-files-not-to-review .file-container:not(.file-to-review-diff) .item-details-body {
-          /* Hide the diff for files I don't have to review. */
-          display: none;
-        }
-        .toolbar-button {
-          background: transparent;
-          color: var(--text-primary-color);
-          border: 1px solid transparent;
-          border-radius: 3px;
-          margin: 0px 2px;
-        }
-        .toolbar-button:hover {
-          border: 1px solid var(--palette-black-alpha-20);
-        }
-        .toolbar-button.active {
-          color: var(--communication-foreground);
-        }`);
-
-      // Get the current iteration of the PR.
-      const prUrl = await getCurrentPullRequestUrlAsync();
-
-      // Get owners info for this PR.
-      const ownersInfo = await getNationalInstrumentsPullRequestOwnersInfo(prUrl);
-      const hasOwnersInfo = ownersInfo && ownersInfo.currentUserFileCount > 0;
-
-      // If we have owners info, add a button to filter out diffs that we don't need to review.
-      if (hasOwnersInfo) {
-        $('.changed-files-summary-toolbar').once('add-other-files-button').each(function () {
-          $(this)
-            .find('ul')
-            .prepend('<li class="menu-item" role="button"><a href="#">Toggle other files</a></li>')
-            .click(event => {
-              $('.files-container').toggleClass('hide-files-not-to-review');
-            });
-        });
-      }
-
-      // If the user presses this button, it will auto-collapse folders in the files tree. Useful for large reviews.
-      let collapseFolderButtonClicks = 0;
-      const collapseFoldersButton = $('<button class="toolbar-button" />')
-        .text('⇐')
-        .attr('title', 'Toggle auto-collapsing folders.')
-        .insertAfter($('.vc-iteration-selector'))
-        .on('click', (event) => {
-          collapseFoldersButton.toggleClass('active');
-          collapseFolderButtonClicks += 1;
-          annotateFilesTreeFunc(); // Kick off the first collapsing, cause this function only runs if something changes in the DOM.
-          event.stopPropagation();
-        });
-
-      annotateFilesTreeFunc = function () {
-        // If we have owners info, tag the diffs that we don't need to review.
-        if (hasOwnersInfo) {
-          $('.file-container .file-path').once('filter-files-to-review').each(function () {
-            const filePathElement = $(this);
-            const path = filePathElement.text().replace(/\//, '');
-            filePathElement.closest('.file-container').toggleClass('file-to-review-diff', ownersInfo.isCurrentUserResponsibleForFile(path));
-          });
-        }
-
-        if (collapseFoldersButton.hasClass('active')) {
-          // The toggle folder collapsible button is active. Let's collapse folders that we've marked as collapsible.
-          $('.auto-collapsible-folder').once(`collapse-${collapseFolderButtonClicks}`).each(async function () {
-            const row = $(this);
-            let attemptsLeft = 3; // This is gross, but sometimes the folder doesn't actually collapse. So let's wait a bit and check again.
-            while (attemptsLeft > 0 && row.attr('aria-expanded') === 'true') {
-              row.find('.expand-icon').click();
-              // eslint-disable-next-line no-await-in-loop
-              await sleep(300);
-              attemptsLeft -= 1;
-            }
-          });
-        }
-
-        $('.vc-sparse-files-tree .vc-tree-cell').once('annotate-with-owners-info').each(function () {
-          const fileCell = $(this);
-          const fileRow = fileCell.closest('.tree-row');
-          const listItem = fileRow.parent()[0];
-          const typeIcon = fileRow.find('.type-icon');
-
-          const { fullName: pathWithLeadingSlash, isFolder, depth } = getPropertyThatStartsWith(listItem, '__reactEventHandlers$').children.props.item;
-          const path = pathWithLeadingSlash.substring(1); // Remove leading slash.
-
-          // Don't do anything at the root.
-          if (depth === 0) {
-            return;
-          }
-
-          // If we have owners info, mark folders that have files we need to review. This will allow us to highlight them if they are collapsed.
-          const folderContainsFilesToReview = hasOwnersInfo && isFolder && ownersInfo.isCurrentUserResponsibleForFileInFolderPath(`${path}/`);
-          fileRow.toggleClass('folder-to-review-row', folderContainsFilesToReview);
-          fileRow.toggleClass('auto-collapsible-folder', !folderContainsFilesToReview);
-
-          // Don't put checkboxes on rows that don't represent files.
-          if (!/bowtie-file\b/i.test(typeIcon.attr('class'))) {
-            return;
-          }
-
-          // If we have owners info, highlight the files we need to review and add role info.
-          if (hasOwnersInfo && ownersInfo.isCurrentUserResponsibleForFile(path)) {
-            fileRow.addClass('file-to-review-row');
-            $('<div class="file-owners-role" />').text(`${ownersInfo.currentUserFilesToRole[path]}:`).prependTo(fileRow);
-          }
-        });
-      };
-    });
-
-    annotateFilesTreeFunc();
-  }
 
   // If we're on specific PR, add a base update selector.
   function addBaseUpdateSelector() {
@@ -1112,6 +964,87 @@
         <div class="bolt-pill-content text-ellipsis">${html}</div>
       </div>`;
     labels.insertAdjacentHTML('beforeend', label);
+  }
+
+  let ownersInfo;
+
+  function onFilesTreeChange() {
+    const hasOwnersInfo = ownersInfo && ownersInfo.currentUserFileCount > 0;
+
+    $('.repos-changes-explorer-tree .bolt-tree-row').each(function () {
+      const fileRow = $(this);
+      const text = $(this).find('span.text-ellipsis');
+      const item = text.parent();
+
+      const pathAndChangeType = getPropertyThatStartsWith(item[0], '__reactInternalInstance$').memoizedProps.children[1].props.text;
+      const pathWithLeadingSlash = pathAndChangeType.replace(/ \[[a-z]+\]( renamed from .+)?$/, '');
+      const path = pathWithLeadingSlash.substring(1); // Remove leading slash.
+
+      const isFolder = item[0].children[0].classList.contains('repos-folder-icon');
+
+      // If we have owners info, mark folders that have files we need to review. This will allow us to highlight them if they are collapsed.
+      const folderContainsFilesToReview = hasOwnersInfo && isFolder && ownersInfo.isCurrentUserResponsibleForFileInFolderPath(`${path}/`);
+      fileRow.toggleClass('folder-to-review-row', folderContainsFilesToReview);
+      fileRow.toggleClass('auto-collapsible-folder', !folderContainsFilesToReview);
+
+      // If we have owners info, highlight the files we need to review and add role info.
+      const isFileToReview = hasOwnersInfo && !isFolder && ownersInfo.isCurrentUserResponsibleForFile(path);
+      item.parent().toggleClass('file-to-review-row', isFileToReview);
+      if (isFileToReview) {
+        if (fileRow.find('.file-owners-role').length === 0) {
+          $('<div class="file-owners-role" />').text(`${ownersInfo.currentUserFilesToRole[path]}:`).prependTo(item.parent());
+        }
+      } else {
+        fileRow.find('.file-owners-role').remove();
+      }
+    });
+  }
+
+  function watchFilesTree() {
+    addStyleOnce('pr-file-tree-annotations-css', /* css */ `
+        :root {
+          /* Set some constants for our CSS. */
+          --file-to-review-color: var(--communication-foreground);
+        }
+        .repos-changes-explorer-tree .file-to-review-row,
+        .repos-changes-explorer-tree .file-to-review-row .text-ellipsis {
+          /* Highlight files I need to review. */
+          color: var(--file-to-review-color) !important;
+          transition-duration: 0.2s;
+        }
+        .repos-changes-explorer-tree .folder-to-review-row[aria-expanded='false'],
+        .repos-changes-explorer-tree .folder-to-review-row[aria-expanded='false'] .text-ellipsis {
+          /* Highlight folders that have files I need to review, but only when files are hidden cause the folder is collapsed. */
+          color: var(--file-to-review-color);
+          transition-duration: 0.2s;
+        }
+        .repos-changes-explorer-tree .file-to-review-row .file-owners-role {
+          /* Style the role of the user in the files table. */
+          font-weight: bold;
+          padding: 7px 10px;
+          position: absolute;
+          z-index: 100;
+          float: right;
+        }`);
+
+    eus.onUrl(/\/pullrequest\//gi, (session, urlMatch) => {
+      session.onEveryNew(document, '.repos-changes-explorer-tree', async tree => {
+        // Get the current iteration of the PR.
+        const prUrl = await getCurrentPullRequestUrlAsync();
+        // Get owners info for this PR.
+        ownersInfo = await getNationalInstrumentsPullRequestOwnersInfo(prUrl);
+
+        const hasOwnersInfo = ownersInfo && ownersInfo.currentUserFileCount > 0;
+
+        if (hasOwnersInfo) {
+          const onFilesTreeChangeThrottled = _.throttle(onFilesTreeChange, 400, { leading: false, trailing: true });
+          session.onAnyChangeTo(tree, tree => {
+            onFilesTreeChangeThrottled();
+          });
+          onFilesTreeChangeThrottled();
+        }
+      });
+    });
   }
 
   function watchForNewDiffs(isDarkTheme) {


### PR DESCRIPTION
This also removes the code for certain features that haven't been reimplemented for the new PR experience, like the collapse folders button.

This change implements the blue highlighting plus the role indicator (i.e. "O:") prepended to the highlighted lines. It also implements the collapsed folder highlighting, when they contain files to review.