### PR TITLE
Fix highlighting when files tree has comments

### DIFF
--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 
 // @name         AzDO Pull Request Improvements
-// @version      2.53.0
+// @version      2.53.1
 // @author       Alejandro Barreto (National Instruments)
 // @description  Adds sorting and categorization to the PR dashboard. Also adds minor improvements to the PR diff experience, such as a base update selector and per-file checkboxes.
 // @license      MIT
@@ -968,6 +968,11 @@
       const fileRow = $(this);
       const text = fileRow.find('span.text-ellipsis');
       const item = text.parent();
+
+      // For non-file/folder items in the tree (e.g. comments), we won't find a text span
+      if (text.length === 0) {
+        return;
+      }
 
       /* eslint no-underscore-dangle: ["error", { "allow": ["_owner"] }] */
       const pathAndChangeType = getPropertyThatStartsWith(text[0], '__reactInternalInstance$').memoizedProps.children._owner.stateNode.props.data.path;


### PR DESCRIPTION
When someone leaves comments on a file, it puts an item in the files tree. These items do not have text spans like we're looking for, and so we get an error when trying to find the react property. That prevents highlighting from populating properly.