### PR TITLE
Add a copy branch name button to Git repo pages

### DIFF
--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -516,6 +516,36 @@
       container.append(banner);
 
       voteButton.append(container);
+      $(voteButton).prepend($(`<div
+  class="
+    repos-pr-header-vote-button
+    bolt-split-button
+    flex-stretch
+    inline-flex-row
+  "
+>
+  <div class="bypass-reminder-container">
+    <div
+      class="
+        bolt-split-button
+        flex-stretch
+        inline-flex-row
+        vote-button-wrapper
+      "
+    >
+      <button
+        class="bolt-split-button-main bolt-button enabled bolt-focus-treatment"
+        data-focuszone="focuszone-3"
+        data-is-focusable="true"
+        role="button"
+        tabindex="0"
+        type="button"
+      >
+        <span class="bolt-button-text body-m">Bypass Owners</span>
+      </button>
+    </div>
+  </div>
+</div>`).click(async function (x) { $('#__bolt-menu-button-1').click(); await eus.sleep(200); $('#__bolt-ext-menu-148-text').click(); }));
     }
   }
 

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 
 // @name         More Awesome Azure DevOps (userscript)
-// @version      3.0.2
+// @version      3.1.0
 // @author       Alejandro Barreto (NI)
 // @description  Makes general improvements to the Azure DevOps experience, particularly around pull requests. Also contains workflow improvements for NI engineers.
 // @license      MIT
@@ -119,6 +119,7 @@
 
     eus.onUrl(/\/(_git)/gi, (session, urlMatch) => {
       doEditAction(session);
+      watchForRepoBrowsingPages(session);
     });
 
     // Throttle page update events to avoid using up CPU when AzDO is adding a lot of elements during a short time (like on page load).
@@ -318,6 +319,36 @@
 
     const annotation = `<div class="work-item-followers-list" style="margin: 1em 0em; opacity: 0.8"><span class="menu-item-icon bowtie-icon bowtie-watch-eye-fill" aria-hidden="true"></span> ${followerList}</div>`;
     commentEditor.insertAdjacentHTML('BeforeEnd', annotation);
+  }
+
+  function watchForRepoBrowsingPages(session) {
+    // Add a copy branch button.
+    session.onEveryNew(document, '.version-dropdown > button', versionSelector => {
+      if (eus.seen(versionSelector)) return;
+
+      const copyButton = $('<button />')
+        .attr('class', 'bolt-header-command-item-button bolt-button bolt-icon-button enabled bolt-focus-treatment')
+        .css('font-family', 'Bowtie')
+        .css('font-size', '14px')
+        .css('font-weight', 'normal')
+        .attr('title', 'Copy branch name to clipboard')
+        .text('\uE94B') // A copy icon in the Bowtie font.
+        .click(event => {
+          const branchName = $(versionSelector).find('.bolt-dropdown-expandable-button-label').text();
+
+          navigator.clipboard.writeText(branchName);
+
+          eus.toast.fire({
+            title: 'AzDO userscript',
+            text: `Copied branch name to clipboard: ${branchName}`,
+            icon: 'info',
+          });
+
+          event.stopPropagation();
+        });
+
+      $(versionSelector).after(copyButton);
+    });
   }
 
   function watchForShowMoreButtons() {
@@ -545,7 +576,7 @@
       </button>
     </div>
   </div>
-</div>`).click(async function (x) { $('#__bolt-menu-button-1').click(); await eus.sleep(200); $('#__bolt-ext-menu-148-text').click(); }));
+</div>`).click(async (x) => { $('#__bolt-menu-button-1').click(); await eus.sleep(200); $('#__bolt-ext-menu-148-text').click(); }));
     }
   }
 

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -547,36 +547,6 @@
       container.append(banner);
 
       voteButton.append(container);
-      $(voteButton).prepend($(`<div
-  class="
-    repos-pr-header-vote-button
-    bolt-split-button
-    flex-stretch
-    inline-flex-row
-  "
->
-  <div class="bypass-reminder-container">
-    <div
-      class="
-        bolt-split-button
-        flex-stretch
-        inline-flex-row
-        vote-button-wrapper
-      "
-    >
-      <button
-        class="bolt-split-button-main bolt-button enabled bolt-focus-treatment"
-        data-focuszone="focuszone-3"
-        data-is-focusable="true"
-        role="button"
-        tabindex="0"
-        type="button"
-      >
-        <span class="bolt-button-text body-m">Bypass Owners</span>
-      </button>
-    </div>
-  </div>
-</div>`).click(async (x) => { $('#__bolt-menu-button-1').click(); await eus.sleep(200); $('#__bolt-ext-menu-148-text').click(); }));
     }
   }
 


### PR DESCRIPTION
From a user:

This has frustrated me a few times.  I want to git checkout some long branch name and I'm starting with a link that takes me to the branch in AzDO (e.g. this).

However, the place on this page that shows you what the branch name is does not allow you to select the text.  I can right-click the drop-down element and click Inspect, and that will get me to the raw text in the markup fairly quickly, but it shouldn't have to be like that.