### PR TITLE
Do not try to get InnerText for undefined element in Protocol Handler

### DIFF
--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -955,9 +955,10 @@
 
     session.onEveryNew(document, '.bolt-messagebar.severity-info .bolt-messagebar-buttons', boltMessageBarButtons => {
       const reposSummaryHeader = $(boltMessageBarButtons).closest('.repos-summary-header');
-      const filePath = (reposSummaryHeader.length > 0 ? reposSummaryHeader : $('.repos-compare-toolbar'))
-        .find('.secondary-text.text-ellipsis')[0].innerText;
+      const filePathElement = (reposSummaryHeader.length > 0 ? reposSummaryHeader : $('.repos-compare-toolbar')).find('.secondary-text.text-ellipsis')[0];
+      if (!filePathElement) return;
 
+      const filePath = filePathElement.innerText;
       if (!supportedFileExtensions.includes(getFileExt(filePath))) return;
 
       const launchDiffButton = $('<button class="bolt-button flex-grow-2 ni-binary-git-diff-button">Launch NI Binary Git Diff ▶</button>');


### PR DESCRIPTION
# Description

Some people are having issues when they try to display the button for the VI Diff protocol handler.

# Implementation

The issue is that sometimes the element does not contain any InnerText yet, so it errors out.

# Testing

Asked the person who was able to reproduce this to test it and the problem went away.