### PR TITLE
Feat: Highlight Offline Agents

### DIFF
--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -130,6 +130,10 @@
       addEditButtons(session);
     });
 
+    eus.onUrl(/\/agentqueues(\?|\/)/gi, (session, urlMatch) => {
+      watchForAgentPage(session, pageData);
+    });
+
     eus.onUrl(/\/(_git)/gi, (session, urlMatch) => {
       doEditAction(session);
       watchForRepoBrowsingPages(session);
@@ -195,6 +199,14 @@
     }
 
     return value;
+  }
+
+  async function watchForAgentPage(session, pageData) {
+    addStyleOnce('agent-css', /* css */ `
+      .agent-icon.offline {
+        width: 250px !important;
+      }
+    `);
   }
 
   async function watchForReviewerList(session) {


### PR DESCRIPTION
# Details
It is hard to navigate the `Agent Pool` pages on Azdo to search for offline agents because there is no search bar.
Ideally, it would be better to implement a search, but this is easier to implement in the short term.

# Implementation
Customize width for the `.agent-icon.offline` class.

# Testing
**Before**
![image](https://user-images.githubusercontent.com/8660999/157733015-9714d3dd-7728-42c3-abed-998737df3641.png)

**After**
![image](https://user-images.githubusercontent.com/8660999/157733091-87a5c464-6173-418d-aead-fd5522459a6c.png)
