### PR TITLE
Fix: watchfor agentqueues also needs to watch for agentpools

### DIFF
--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 
 // @name         More Awesome Azure DevOps (userscript)
-// @version      3.3.3
+// @version      3.3.4
 // @author       Alejandro Barreto (NI)
 // @description  Makes general improvements to the Azure DevOps experience, particularly around pull requests. Also contains workflow improvements for NI engineers.
 // @license      MIT

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -130,7 +130,7 @@
       addEditButtons(session);
     });
 
-    eus.onUrl(/\/agentqueues(\?|\/)/gi, (session, urlMatch) => {
+    eus.onUrl(/\/(agentqueues|agentpools)(\?|\/)/gi, (session, urlMatch) => {
       watchForAgentPage(session, pageData);
     });
 


### PR DESCRIPTION
# Details

From my previous PR:
[!182](https://github.com/alejandro5042/azdo-userscripts/pull/182)

I also noticed that sometimes azdo uses the `agentpools` for displaying agents.

# Implementation

Also include `agentpools` in `watchForAgentPage`

# Testing

![image](https://user-images.githubusercontent.com/8660999/157933344-bdcf39ce-0cc1-48a1-9376-2bc8c9bbaf85.png)
