### PR TITLE
Feat: Add Custom Agent Filtering

### DIFF
--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 
 // @name         More Awesome Azure DevOps (userscript)
-// @version      3.3.4
+// @version      3.3.5
 // @author       Alejandro Barreto (NI)
 // @description  Makes general improvements to the Azure DevOps experience, particularly around pull requests. Also contains workflow improvements for NI engineers.
 // @license      MIT
@@ -131,7 +131,7 @@
     });
 
     eus.onUrl(/\/(agentqueues|agentpools)(\?|\/)/gi, (session, urlMatch) => {
-      watchForAgentPage(session, pageData);
+      // watchForAgentPage(session, pageData);
     });
 
     eus.onUrl(/\/(_git)/gi, (session, urlMatch) => {

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -131,7 +131,7 @@
     });
 
     eus.onUrl(/\/(agentqueues|agentpools)(\?|\/)/gi, (session, urlMatch) => {
-      // watchForAgentPage(session, pageData);
+      watchForAgentPage(session, pageData);
     });
 
     eus.onUrl(/\/(_git)/gi, (session, urlMatch) => {

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -259,7 +259,6 @@
               </div>
           </div>
         </div>`;
-        // <span class="left-icon flex-noshrink fabric-icon ms-Icon--Refresh medium" style="padding: 5px 0px 0px 10px;"/>
         $(agentsTable).prepend(agentFilterBarElement);
         document.getElementById('agentFilterInput').addEventListener('input', filterAgentsDebouncer());
         document.getElementById('agentFilterRefresh').addEventListener('click', filterAgentsDebouncer());


### PR DESCRIPTION
# Justification

For large AzDO pools, it is hard to find agents that need special attention like offline or disabled ones.

# Implementation

- Inject a custom regex search bar to the Agent Pool page
- Add a count to the search bar
- Refresh the filter every 10 seconds because the table updates automatically
- Add a button to refresh on demand

# Testing

**Before**
![image](https://user-images.githubusercontent.com/8660999/162042445-440b95eb-e68c-4b1d-a1eb-6e11d3a51608.png)

**After**
1. Show all mac agents:
![image](https://user-images.githubusercontent.com/8660999/162042647-0d4f71f2-1796-4963-b799-41cced07f0b9.png)

1. Show all offline agents:
![image](https://user-images.githubusercontent.com/8660999/162043270-2e3f476d-2d0f-456a-9d7e-12ccbc238090.png)

1. Show all disabled agents (Off)
![image](https://user-images.githubusercontent.com/8660999/162042920-1dc1fd3a-08f1-41e8-8d9e-537ae0a09013.png)
