### PR TITLE
feat: Add DISABLE_REASON to Agents List

### DIFF
--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 
 // @name         More Awesome Azure DevOps (userscript)
-// @version      3.3.6
+// @version      3.4.0
 // @author       Alejandro Barreto (NI)
 // @description  Makes general improvements to the Azure DevOps experience, particularly around pull requests. Also contains workflow improvements for NI engineers.
 // @license      MIT
@@ -315,7 +315,9 @@
         totalCount += 1;
         agentRow.classList.remove('hiddenAgentRow');
         agentRow.classList.remove('visibleAgentRow');
-        await addAgentDisableReason(agentRow);
+        if (atNI) {
+          await addAgentDisableReason(agentRow);
+        }
 
         const rowValue = agentRow.innerText.replace(/[\r\n]/g, '').trim();
         if (!regexFilter.test(rowValue)) {

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 
 // @name         More Awesome Azure DevOps (userscript)
-// @version      3.3.5
+// @version      3.3.6
 // @author       Alejandro Barreto (NI)
 // @description  Makes general improvements to the Azure DevOps experience, particularly around pull requests. Also contains workflow improvements for NI engineers.
 // @license      MIT

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -206,6 +206,14 @@
       .agent-icon.offline {
         width: 250px !important;
       }
+      .disable-reason {
+        padding: 5px;
+        border-radius: 20px;
+        margin-right: 3px;
+        font-size: 12px;
+        text-decoration: none;
+        background: var(--search-selected-match-background);
+      }
     `);
 
     session.onEveryNew(document, '.pipelines-pool-agents.page-content.page-content-top', agentsTable => {
@@ -267,7 +275,7 @@
     });
 
     // Status of agents can change as the table is constantly updating.
-    setInterval(filterAgentsDebouncer(), 10000);
+    setInterval(filterAgentsDebouncer(), 30000);
   }
 
   function filterAgentsDebouncer() {
@@ -279,7 +287,7 @@
     };
   }
 
-  function filterAgents() {
+  async function filterAgents() {
     let regexFilterString;
     let regexFilter;
     try {
@@ -303,10 +311,11 @@
     let matchedCount = 0;
     const agentRows = document.querySelectorAll('a.bolt-list-row.single-click-activation');
     try {
-      agentRows.forEach(agentRow => {
+      await Promise.all(Array.from(agentRows).map(async (agentRow) => {
         totalCount += 1;
         agentRow.classList.remove('hiddenAgentRow');
         agentRow.classList.remove('visibleAgentRow');
+        await addAgentDisableReason(agentRow);
 
         const rowValue = agentRow.innerText.replace(/[\r\n]/g, '').trim();
         if (!regexFilter.test(rowValue)) {
@@ -315,12 +324,51 @@
           matchedCount += 1;
           agentRow.classList.add('visibleAgentRow');
         }
-      });
+      }));
       $('.visibleAgentRow').show();
       $('.hiddenAgentRow').hide();
       document.getElementById('agentFilterCounter').innerText = `(${matchedCount}/${totalCount})`;
     } catch (e) {
       showAllAgents(e);
+    }
+  }
+
+  async function addAgentDisableReason(agentRow) {
+    const poolName = Array.from(document.querySelectorAll('div.bolt-breadcrumb-item-text-container')).pop().innerText;
+    const currentPoolId = await fetchJsonAndCache(
+      `azdoPool${poolName}Id`,
+      12 * 60 * 60,
+      `${azdoApiBaseUrl}/_apis/distributedtask/pools?poolName=${poolName}`,
+      1,
+      poolInfo => poolInfo.value[0].id,
+    );
+
+    const agentCells = agentRow.querySelectorAll('div');
+    const agentName = agentCells[1].innerText;
+    const agentInfo = await fetchJsonAndCache(
+      `azdoPoolId${currentPoolId}azdoAgent${agentName}`,
+      2,
+      `${azdoApiBaseUrl}/_apis/distributedtask/pools/${currentPoolId}/agents?agentName=${agentName}&includeCapabilities=True`,
+      1,
+      agentInfoJson => agentInfoJson.value[0],
+    );
+
+    $(agentRow).find('.disable-reason').remove();
+    if (agentInfo.userCapabilities) {
+      const disableReason = agentInfo.userCapabilities.DISABLE_REASON || null;
+      if (disableReason) {
+        const userIcon = document.createElement('span');
+        userIcon.className = 'fabric-icon ms-Icon--Contact';
+
+        const disableReasonMessage = document.createElement('a');
+        disableReasonMessage.className = 'disable-reason';
+        disableReasonMessage.text = ' Reserved';
+        disableReasonMessage.href = `${azdoApiBaseUrl}/_settings/agentpools?agentId=${agentInfo.id}&poolId=${currentPoolId}&view=capabilities`;
+        disableReasonMessage.prepend(userIcon);
+        disableReasonMessage.title = disableReason;
+
+        $(agentCells[5]).prepend(disableReasonMessage);
+      }
     }
   }
 


### PR DESCRIPTION
# Justification
We added an internal mechanism to "reserve" agents by adding a "user capability" to agents in AzDO called `DISABLE_REASON`.
This way we know if an agent has been reserved by someone or something.
Now we want to be able to see from the Agent Page if the agent was reserved by querying that capability.

Note - The DISABLE_REASON will only work `if (atNI)`

# Implementation
While filtering the agents in the Agent Page, query the agents' capabilities and if the capability `DISABLE_REASON` is set, append an HTML element with the information.gim

# Testing
![image](https://user-images.githubusercontent.com/8660999/177616754-b0db07d7-1fe8-4e65-b69f-7c98e24b67c2.png)
