### PR TITLE
Align known_issues.json match_flag field with pipeline-csv.ps1

### DIFF
--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 
 // @name         More Awesome Azure DevOps (userscript)
-// @version      3.4.5
+// @version      3.4.6
 // @author       Alejandro Barreto (NI)
 // @description  Makes general improvements to the Azure DevOps experience, particularly around pull requests. Also contains workflow improvements for NI engineers.
 // @license      MIT

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1719,9 +1719,11 @@
               for (let k = 0; k < knownBuildErrors.length; k += 1) {
                 if (knownBuildErrors[k].category === 'Infrastructure' && new RegExp(knownBuildErrors[k].pipeline_match).test(pipelineName)) {
                   const matchString = knownBuildErrors[k].match;
-                  let matchFlag = 'g';
-                  if (knownBuildErrors[k].match_flag === 'dotmatchall') {
-                    matchFlag = 'gs';
+                  let matchFlag = 'gi';
+                  if (knownBuildErrors[k].match_flag === 'multiline') {
+                    matchFlag = 'gim';
+                  } else if (knownBuildErrors[k].match_flag === 'dotmatchall') {
+                    matchFlag = 'gis';
                   }
                   const matches = log.match(new RegExp(matchString, matchFlag)) || [];
                   if (matches.length) {


### PR DESCRIPTION
This script uses the `known-issues.json` file owned by the `pipeline-csv.ps1` script. The `match_flag` behavior is different than the script. This PR fixes that.

The [pipeline-csv.ps1 script](https://dev.azure.com/ni/DevCentral/_git/Tools?path=/report/build_failure_analysis/pipeline-results/pipeline-csv.ps1&version=GBmain&line=125&lineEnd=125&lineStartColumn=35&lineEndColumn=44&lineStyle=plain&_a=contents) prepends the match with `(?m)` if `match_flag` is equal to `multiline` and if it isn't, it prepends the match with `(?s)` if `match_flag` equals `dotmatchall`. If the match_all field doesn't match either then the flags used are not modified.

```powershell
        if ($item.match_flag -eq "multiline") {
            $item.match = "(?m)$($item.match)"
        }
        elseif ($item.match_flag -eq "dotmatchall") {
            $item.match = "(?s)$($item.match)"
        }

...

    foreach ($def in $definitions) {
        if ($def.name -match $defRegex) {
            $defIds += $def.id
            Write-Host "$($def.name)"
        }
    }

```

- `(?m)`: `^$` [match line endings instead of string endings](https://stackoverflow.com/questions/27680097/what-does-ms-in-regex-mean)
- `(?s)`: `.` [matches carriage return and linefeed characters](https://stackoverflow.com/questions/27680097/what-does-ms-in-regex-mean)
- `pipeline-csv.ps1 script` uses `-match` [which in powershell is a synonym](https://community.idera.com/database-tools/powershell/ask_the_experts/f/learn_powershell_from_don_jones-24/20667/match-and-imatch) for `-imatch`, which is a case insensitive match

In [javascript, the equivalent](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#advanced_searching_with_flags) of:
- `(?m)` is `m`
- `(?s)` is `s` (already handled)
- `-match` is `i`

