### PR TITLE
feat: Get pool agent info at once

### DIFF
--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 
 // @name         More Awesome Azure DevOps (userscript)
-// @version      3.4.1
+// @version      3.4.2
 // @author       Alejandro Barreto (NI)
 // @description  Makes general improvements to the Azure DevOps experience, particularly around pull requests. Also contains workflow improvements for NI engineers.
 // @license      MIT


### PR DESCRIPTION
Currently, the feature to get the disable reason per agent gets the info per agent which can get slow.
To improve this, we should get all the agent info at once instead

