### PR TITLE
Don't show build status on PR summary page when no builds exist

### DIFF
--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1618,7 +1618,7 @@
     if (!pr.lastMergeCommit) return;
 
     const builds = (await $.get(`${pr.lastMergeCommit.url}/statuses?api-version=5.1&latestOnly=true`)).value;
-    if (!builds) return;
+    if (!(builds && builds.length)) return;
 
     let state;
     if (builds.every(b => b.state === 'succeeded' || b.description.includes('partially succeeded'))) {


### PR DESCRIPTION
See issue #227.

Verified that some PRs with no builds correctly show no build status icon:
![image](https://github.com/alejandro5042/azdo-userscripts/assets/60117794/a868e7d3-17a8-4ad4-9d37-c14c20e1c4b6)