### PR TITLE
Bump version to 3.6.1

### DIFF
--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 
 // @name         More Awesome Azure DevOps (userscript)
-// @version      3.6.0
+// @version      3.6.1
 // @author       Alejandro Barreto (NI)
 // @description  Makes general improvements to the Azure DevOps experience, particularly around pull requests. Also contains workflow improvements for NI engineers.
 // @license      MIT


### PR DESCRIPTION
I forgot to bump the script version in #228 & #229. That means the CI pipeline fails with a version already exists error.

Bump the version to fix this.