### PR TITLE
Don't show Last Reviewer for Optional/Declined PRs (#167)

### DIFF
--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1469,7 +1469,7 @@
       await annotateFileCountOnPullRequestRow(row, pr);
       await annotateBuildStatusOnPullRequestRow(row, pr);
 
-      if (votes.userVote === 0 && votes.missingVotes === 1) {
+      if (votes.userVote === 0 && votes.missingVotes === 1 && votes.userIsRequired && !votes.userHasDeclined) {
         annotatePullRequestTitle(row, 'repos-pr-list-late-review-pill', 'Last Reviewer', 'Everyone is waiting on you!');
       }
 
@@ -1538,11 +1538,15 @@
       missingVotes: 0,
       waitingOrRejectedVotes: 0,
       userVote: 0,
+      userIsRequired: true,
+      userHasDeclined: false,
     };
 
     for (const reviewer of pr.reviewers) {
       if (reviewer.uniqueName === currentUser.uniqueName) {
         votes.userVote = reviewer.vote;
+        votes.userIsRequired = reviewer.isRequired;
+        votes.userHasDeclined = reviewer.hasDeclined;
       }
       if (reviewer.vote === 0) {
         votes.missingVotes += 1;

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 
 // @name         More Awesome Azure DevOps (userscript)
-// @version      3.6.1
+// @version      3.6.2
 // @author       Alejandro Barreto (NI)
 // @description  Makes general improvements to the Azure DevOps experience, particularly around pull requests. Also contains workflow improvements for NI engineers.
 // @license      MIT


### PR DESCRIPTION
Only show the _Last Reviewer_ pill for _Required_ PRs that have not been _Declined_. This assumes [Azure DevOps Services REST API 6.0](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-request-reviewers/update-pull-request-reviewer?view=azure-devops-rest-6.0) or later.