### PR TITLE
Fix linting errors to un-break build

### DIFF
--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -770,9 +770,9 @@
 
           if (employee.status) {
             let status = employee.status;
-            if (status === "Leave Without Pay") {
+            if (status === 'Leave Without Pay') {
               // Be nice and not show this status like this.
-              status = "On Leave"
+              status = 'On Leave';
             }
             annotateReviewer(nameElement, 'ooo', escapeStringForHtml(status));
           }


### PR DESCRIPTION
The last build failed with a linting error, so fix that up by running `npx eslint --fix`. Now `npm run build` succeeds locally.