### PR TITLE
Add source branch and hide common target branches in PR dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ By default, Violentmonkey will auto-update scripts from the original install loc
 - Reviews show build status (if it's empty, there isn't a merge commit or a build configured)
 - If a PR has bug work items associated with it, we add a label with the severity of such bugs (if SEV == 1 or 2)
 - Repo pull request listings will also link to the overall account-wide PR dashboard
+- Each PR is annotated with source branch name.
+- Target branch is hidden for PRs targeting `main` or `master`.
+- Source and/or target branch name are abbreviated if they start with `users/<name>/`.
 - At [NI](https://www.ni.com), some labels get coloring (e.g. "bypass owners" gets a red background)
 - At [NI](https://www.ni.com), reviews are annotated with how long you've been on it if it's been over 1 weekday and you haven't voted or commented
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ By default, Violentmonkey will auto-update scripts from the original install loc
 - Repo pull request listings will also link to the overall account-wide PR dashboard
 - Each PR is annotated with source branch name.
 - Target branch is hidden for PRs targeting `main` or `master`.
-- Source and/or target branch name are abbreviated if they start with `users/<name>/`.
 - At [NI](https://www.ni.com), some labels get coloring (e.g. "bypass owners" gets a red background)
 - At [NI](https://www.ni.com), reviews are annotated with how long you've been on it if it's been over 1 weekday and you haven't voted or commented
 

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -82,7 +82,7 @@
         <ul>
           <li>Source branch name is now shown for each PR.</li>
           <li>Target branch name is hidden if it's <code>main</code> or <code>master</code>.</li>
-          <li>Branch names like <code>users/name/foo</code> are abbreviated to <code>u/n/foo</code>.</li>
+          <li>Branch names like <code>users/name/foo</code> are abbreviated to <code><span class="flex-noshrink fabric-icon ms-Icon--Contact medium"></span>/foo</code>.</li>
         </ul>
         <p>Comments, bugs, suggestions? File an issue on <a href="https://github.com/alejandro5042/azdo-userscripts" target="_blank">GitHub</a> 🧡</p>
       `);
@@ -1683,10 +1683,16 @@
     if (!pr.lastMergeCommit) return;
 
     let sourceBranch = pr.sourceRefName.replace(/^refs\/heads\//, '');
-    // Abbreviate e.g. 'users/kroeschl/foo' as 'u/k/foo' to save space
-    sourceBranch = sourceBranch.replace(/^users\/([^/])[^/]*\//, 'u/$1/');
-    const secondary = row.querySelector('.secondary-text span');
+    // Abbreviate e.g. 'users/kroeschl/foo' as '👤/foo' to save space
+    sourceBranch = sourceBranch.replace(/^users\/[^/]+\//, '/');
+    let sourceBranchIcon = '';
+    // Weird margin/padding to make this inline with the text
+    const userIcon = '<span class="fluent-icons-enabled" style="padding-left: 4px; margin-right: -4px"><span aria-hidden="true" class="flex-noshrink fabric-icon ms-Icon--Contact"></span></span>';
+    if (sourceBranch.startsWith('/')) {
+      sourceBranchIcon = userIcon;
+    }
 
+    const secondary = row.querySelector('.secondary-text span');
     if (['refs/heads/master', 'refs/heads/main'].includes(pr.targetRefName)) {
       // Hide target branch and icon if it's main or master, which is very common
       secondary.querySelector('.ms-Icon--OpenSource').remove(); // Branch icon
@@ -1694,13 +1700,17 @@
       secondary.innerHTML = secondary.innerHTML.replace('into ', '');
     } else {
       const targetBranch = pr.targetRefName.replace(/^refs\/heads\//, '');
-      const targetBranchAbbrev = targetBranch.replace(/^users\/([^/])[^/]*\//, 'u/$1/');
-      secondary.innerHTML = secondary.innerHTML.replace(targetBranch, targetBranchAbbrev);
+      const targetBranchAbbrev = targetBranch.replace(/^users\/[^/]+\//, '/');
+      const targetBranchElement = secondary.querySelector('.monospaced-xs');
+      targetBranchElement.innerHTML = targetBranchElement.innerHTML.replace(targetBranch, targetBranchAbbrev);
+      if (targetBranchAbbrev.startsWith('/')) {
+        targetBranchElement.insertAdjacentHTML('beforebegin', userIcon);
+      }
     }
 
     const sourceBranchAnnotation = `from
       <span class="fluent-icons-enabled"><span aria-hidden="true" class="flex-noshrink fabric-icon ms-Icon--OpenSource"
-      ></span></span><span class="monospaced-xs padding-horizontal-4">${sourceBranch}</span>`;
+      ></span></span>${sourceBranchIcon}<span class="monospaced-xs padding-horizontal-4">${sourceBranch}</span>`;
     secondary.insertAdjacentHTML('beforeend', sourceBranchAnnotation);
   }
 

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 
 // @name         More Awesome Azure DevOps (userscript)
-// @version      3.8.2
+// @version      3.9.0
 // @author       Alejandro Barreto (NI)
 // @description  Makes general improvements to the Azure DevOps experience, particularly around pull requests. Also contains workflow improvements for NI engineers.
 // @license      MIT
@@ -1499,6 +1499,7 @@
       await annotateBugsOnPullRequestRow(row, pr);
       await annotateFileCountOnPullRequestRow(row, pr);
       await annotateBuildStatusOnPullRequestRow(row, pr);
+      annotateSourceBranchOnPullRequestRow(row, pr);
 
       if (votes.userVote === 0 && votes.missingVotes === 1 && votes.userIsRequired && !votes.userHasDeclined) {
         annotatePullRequestTitle(row, 'repos-pr-list-late-review-pill', 'Last Reviewer', 'Everyone is waiting on you!');
@@ -1519,6 +1520,7 @@
       await annotateBugsOnPullRequestRow(row, pr);
       await annotateFileCountOnPullRequestRow(row, pr);
       await annotateBuildStatusOnPullRequestRow(row, pr);
+      annotateSourceBranchOnPullRequestRow(row, pr);
     }
   }
 
@@ -1667,6 +1669,20 @@
     const tooltip = _.map(builds, 'description').join('\n');
     const label = `<span aria-hidden="true" class="contributed-icon flex-noshrink fabric-icon ms-Icon--Build"></span>&nbsp;${state}`;
     annotatePullRequestLabel(row, 'build-status', tooltip, label);
+  }
+
+  function annotateSourceBranchOnPullRequestRow(row, pr) {
+    if (!pr.lastMergeCommit) return;
+
+    let sourceBranch = pr.sourceRefName.replace(/^refs\/heads\//, '');
+    // Abbreviate e.g. 'users/kroeschl/foo' as 'u/k/foo' to save space
+    sourceBranch = sourceBranch.replace(/^users\/([^/])[^/]*\//, 'u/$1/');
+    const secondary = row.querySelector('.secondary-text span');
+
+    const sourceBranchAnnotation = `from
+      <span class="fluent-icons-enabled"><span aria-hidden="true" class="flex-noshrink fabric-icon ms-Icon--OpenSource"
+      ></span></span><span class="monospaced-xs padding-horizontal-4">${sourceBranch}</span>`;
+    secondary.insertAdjacentHTML('beforeend', sourceBranchAnnotation);
   }
 
   function annotatePullRequestTitle(row, cssClass, message, tooltip) {

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -82,7 +82,6 @@
         <ul>
           <li>Source branch name is now shown for each PR.</li>
           <li>Target branch name is hidden if it's <code>main</code> or <code>master</code>.</li>
-          <li>Branch names like <code>users/name/foo</code> are abbreviated to <code><span class="flex-noshrink fabric-icon ms-Icon--Contact medium"></span>/foo</code>.</li>
         </ul>
         <p>Comments, bugs, suggestions? File an issue on <a href="https://github.com/alejandro5042/azdo-userscripts" target="_blank">GitHub</a> 🧡</p>
       `);
@@ -1730,15 +1729,7 @@
   function annotateSourceBranchOnPullRequestRow(row, pr) {
     if (!pr.lastMergeCommit) return;
 
-    let sourceBranch = pr.sourceRefName.replace(/^refs\/heads\//, '');
-    // Abbreviate e.g. 'users/kroeschl/foo' as '👤/foo' to save space
-    sourceBranch = sourceBranch.replace(/^users\/[^/]+\//, '/');
-    let sourceBranchIcon = '';
-    // Weird margin/padding to make this inline with the text
-    const userIcon = '<span class="fluent-icons-enabled" style="padding-left: 4px; margin-right: -4px"><span aria-hidden="true" class="flex-noshrink fabric-icon ms-Icon--Contact"></span></span>';
-    if (sourceBranch.startsWith('/')) {
-      sourceBranchIcon = userIcon;
-    }
+    const sourceBranch = pr.sourceRefName.replace(/^refs\/heads\//, '');
 
     const secondary = row.querySelector('.secondary-text span');
     if (['refs/heads/master', 'refs/heads/main'].includes(pr.targetRefName)) {
@@ -1746,19 +1737,11 @@
       secondary.querySelector('.ms-Icon--OpenSource').remove(); // Branch icon
       secondary.querySelector('.monospaced-xs').remove(); // Branch name
       secondary.innerHTML = secondary.innerHTML.replace('into ', '');
-    } else {
-      const targetBranch = pr.targetRefName.replace(/^refs\/heads\//, '');
-      const targetBranchAbbrev = targetBranch.replace(/^users\/[^/]+\//, '/');
-      const targetBranchElement = secondary.querySelector('.monospaced-xs');
-      targetBranchElement.innerHTML = targetBranchElement.innerHTML.replace(targetBranch, targetBranchAbbrev);
-      if (targetBranchAbbrev.startsWith('/')) {
-        targetBranchElement.insertAdjacentHTML('beforebegin', userIcon);
-      }
     }
 
     const sourceBranchAnnotation = `from
       <span class="fluent-icons-enabled"><span aria-hidden="true" class="flex-noshrink fabric-icon ms-Icon--OpenSource"
-      ></span></span>${sourceBranchIcon}<span class="monospaced-xs padding-horizontal-4">${sourceBranch}</span>`;
+      ></span></span><span class="monospaced-xs padding-horizontal-4">${sourceBranch}</span>`;
     secondary.insertAdjacentHTML('beforeend', sourceBranchAnnotation);
   }
 

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1727,6 +1727,13 @@
     sourceBranch = sourceBranch.replace(/^users\/([^/])[^/]*\//, 'u/$1/');
     const secondary = row.querySelector('.secondary-text span');
 
+    if (['refs/heads/master', 'refs/heads/main'].includes(pr.targetRefName)) {
+      // Hide target branch and icon if it's main or master, which is very common
+      secondary.querySelector('.ms-Icon--OpenSource').remove(); // Branch icon
+      secondary.querySelector('.monospaced-xs').remove(); // Branch name
+      secondary.innerHTML = secondary.innerHTML.replace('into ', '');
+    }
+
     const sourceBranchAnnotation = `from
       <span class="fluent-icons-enabled"><span aria-hidden="true" class="flex-noshrink fabric-icon ms-Icon--OpenSource"
       ></span></span><span class="monospaced-xs padding-horizontal-4">${sourceBranch}</span>`;

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -82,7 +82,7 @@
         <ul>
           <li>Source branch name is now shown for each PR.</li>
           <li>Target branch name is hidden if it's <code>main</code> or <code>master</code>.</li>
-          <li>Branch names like <code>users/name/foo</code> are abbreviated to <code>u/n/foo</code>.</li>
+          <li>Branch names like <code>users/name/foo</code> are abbreviated to <code><span class="flex-noshrink fabric-icon ms-Icon--Contact medium"></span>/foo</code>.</li>
         </ul>
         <p>Comments, bugs, suggestions? File an issue on <a href="https://github.com/alejandro5042/azdo-userscripts" target="_blank">GitHub</a> 🧡</p>
       `);
@@ -1731,10 +1731,16 @@
     if (!pr.lastMergeCommit) return;
 
     let sourceBranch = pr.sourceRefName.replace(/^refs\/heads\//, '');
-    // Abbreviate e.g. 'users/kroeschl/foo' as 'u/k/foo' to save space
-    sourceBranch = sourceBranch.replace(/^users\/([^/])[^/]*\//, 'u/$1/');
-    const secondary = row.querySelector('.secondary-text span');
+    // Abbreviate e.g. 'users/kroeschl/foo' as '👤/foo' to save space
+    sourceBranch = sourceBranch.replace(/^users\/[^/]+\//, '/');
+    let sourceBranchIcon = '';
+    // Weird margin/padding to make this inline with the text
+    const userIcon = '<span class="fluent-icons-enabled" style="padding-left: 4px; margin-right: -4px"><span aria-hidden="true" class="flex-noshrink fabric-icon ms-Icon--Contact"></span></span>';
+    if (sourceBranch.startsWith('/')) {
+      sourceBranchIcon = userIcon;
+    }
 
+    const secondary = row.querySelector('.secondary-text span');
     if (['refs/heads/master', 'refs/heads/main'].includes(pr.targetRefName)) {
       // Hide target branch and icon if it's main or master, which is very common
       secondary.querySelector('.ms-Icon--OpenSource').remove(); // Branch icon
@@ -1742,13 +1748,17 @@
       secondary.innerHTML = secondary.innerHTML.replace('into ', '');
     } else {
       const targetBranch = pr.targetRefName.replace(/^refs\/heads\//, '');
-      const targetBranchAbbrev = targetBranch.replace(/^users\/([^/])[^/]*\//, 'u/$1/');
-      secondary.innerHTML = secondary.innerHTML.replace(targetBranch, targetBranchAbbrev);
+      const targetBranchAbbrev = targetBranch.replace(/^users\/[^/]+\//, '/');
+      const targetBranchElement = secondary.querySelector('.monospaced-xs');
+      targetBranchElement.innerHTML = targetBranchElement.innerHTML.replace(targetBranch, targetBranchAbbrev);
+      if (targetBranchAbbrev.startsWith('/')) {
+        targetBranchElement.insertAdjacentHTML('beforebegin', userIcon);
+      }
     }
 
     const sourceBranchAnnotation = `from
       <span class="fluent-icons-enabled"><span aria-hidden="true" class="flex-noshrink fabric-icon ms-Icon--OpenSource"
-      ></span></span><span class="monospaced-xs padding-horizontal-4">${sourceBranch}</span>`;
+      ></span></span>${sourceBranchIcon}<span class="monospaced-xs padding-horizontal-4">${sourceBranch}</span>`;
     secondary.insertAdjacentHTML('beforeend', sourceBranchAnnotation);
   }
 

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1732,6 +1732,10 @@
       secondary.querySelector('.ms-Icon--OpenSource').remove(); // Branch icon
       secondary.querySelector('.monospaced-xs').remove(); // Branch name
       secondary.innerHTML = secondary.innerHTML.replace('into ', '');
+    } else {
+      const targetBranch = pr.targetRefName.replace(/^refs\/heads\//, '');
+      const targetBranchAbbrev = targetBranch.replace(/^users\/([^/])[^/]*\//, 'u/$1/');
+      secondary.innerHTML = secondary.innerHTML.replace(targetBranch, targetBranchAbbrev);
     }
 
     const sourceBranchAnnotation = `from

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1258,6 +1258,11 @@
       .swal2-html-container {
         text-align: left;
       }
+      .swal2-html-container code {
+        background-color: rgba(0,0,0,.06);
+        padding: 0.2em 0.4em;
+        border-radius: 0.2em;
+      }
       .swal2-html-container li {
         list-style: disc;
         margin-left: 4ch;

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1684,6 +1684,10 @@
       secondary.querySelector('.ms-Icon--OpenSource').remove(); // Branch icon
       secondary.querySelector('.monospaced-xs').remove(); // Branch name
       secondary.innerHTML = secondary.innerHTML.replace('into ', '');
+    } else {
+      const targetBranch = pr.targetRefName.replace(/^refs\/heads\//, '');
+      const targetBranchAbbrev = targetBranch.replace(/^users\/([^/])[^/]*\//, 'u/$1/');
+      secondary.innerHTML = secondary.innerHTML.replace(targetBranch, targetBranchAbbrev);
     }
 
     const sourceBranchAnnotation = `from

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1254,6 +1254,11 @@
       .swal2-html-container {
         text-align: left;
       }
+      .swal2-html-container code {
+        background-color: rgba(0,0,0,.06);
+        padding: 0.2em 0.4em;
+        border-radius: 0.2em;
+      }
       .swal2-html-container li {
         list-style: disc;
         margin-left: 4ch;

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1679,6 +1679,13 @@
     sourceBranch = sourceBranch.replace(/^users\/([^/])[^/]*\//, 'u/$1/');
     const secondary = row.querySelector('.secondary-text span');
 
+    if (['refs/heads/master', 'refs/heads/main'].includes(pr.targetRefName)) {
+      // Hide target branch and icon if it's main or master, which is very common
+      secondary.querySelector('.ms-Icon--OpenSource').remove(); // Branch icon
+      secondary.querySelector('.monospaced-xs').remove(); // Branch name
+      secondary.innerHTML = secondary.innerHTML.replace('into ', '');
+    }
+
     const sourceBranchAnnotation = `from
       <span class="fluent-icons-enabled"><span aria-hidden="true" class="flex-noshrink fabric-icon ms-Icon--OpenSource"
       ></span></span><span class="monospaced-xs padding-horizontal-4">${sourceBranch}</span>`;

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 
 // @name         More Awesome Azure DevOps (userscript)
-// @version      3.10.0
+// @version      3.11.0
 // @author       Alejandro Barreto (NI)
 // @description  Makes general improvements to the Azure DevOps experience, particularly around pull requests. Also contains workflow improvements for NI engineers.
 // @license      MIT
@@ -1547,6 +1547,7 @@
       await annotateBugsOnPullRequestRow(row, pr);
       await annotateFileCountOnPullRequestRow(row, pr);
       await annotateBuildStatusOnPullRequestRow(row, pr);
+      annotateSourceBranchOnPullRequestRow(row, pr);
 
       if (votes.userVote === 0 && votes.missingVotes === 1 && votes.userIsRequired && !votes.userHasDeclined) {
         annotatePullRequestTitle(row, 'repos-pr-list-late-review-pill', 'Last Reviewer', 'Everyone is waiting on you!');
@@ -1567,6 +1568,7 @@
       await annotateBugsOnPullRequestRow(row, pr);
       await annotateFileCountOnPullRequestRow(row, pr);
       await annotateBuildStatusOnPullRequestRow(row, pr);
+      annotateSourceBranchOnPullRequestRow(row, pr);
     }
   }
 
@@ -1715,6 +1717,20 @@
     const tooltip = _.map(builds, 'description').join('\n');
     const label = `<span aria-hidden="true" class="contributed-icon flex-noshrink fabric-icon ms-Icon--Build"></span>&nbsp;${state}`;
     annotatePullRequestLabel(row, 'build-status', tooltip, label);
+  }
+
+  function annotateSourceBranchOnPullRequestRow(row, pr) {
+    if (!pr.lastMergeCommit) return;
+
+    let sourceBranch = pr.sourceRefName.replace(/^refs\/heads\//, '');
+    // Abbreviate e.g. 'users/kroeschl/foo' as 'u/k/foo' to save space
+    sourceBranch = sourceBranch.replace(/^users\/([^/])[^/]*\//, 'u/$1/');
+    const secondary = row.querySelector('.secondary-text span');
+
+    const sourceBranchAnnotation = `from
+      <span class="fluent-icons-enabled"><span aria-hidden="true" class="flex-noshrink fabric-icon ms-Icon--OpenSource"
+      ></span></span><span class="monospaced-xs padding-horizontal-4">${sourceBranch}</span>`;
+    secondary.insertAdjacentHTML('beforeend', sourceBranchAnnotation);
   }
 
   function annotatePullRequestTitle(row, cssClass, message, tooltip) {

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -76,10 +76,13 @@
         'agent-arbitration-status-off': 'Off',
       });
 
-      eus.showTipOnce('release-2026-04-15', 'New in the AzDO userscript', `
-        <p>Highlights from the 2026-04-15 update!</p>
+      eus.showTipOnce('release-2026-04-17', 'New in the AzDO userscript', `
+        <p>Highlights from the 2026-04-17 update!</p>
+        <p>Changes to the PR dashboard view:</p>
         <ul>
-          <li>Fix: correct labels container position in the PR dashboard. (#245)</li>
+          <li>Source branch name is now shown for each PR.</li>
+          <li>Target branch name is hidden if it's <code>main</code> or <code>master</code>.</li>
+          <li>Branch names like <code>users/name/foo</code> are abbreviated to <code>u/n/foo</code>.</li>
         </ul>
         <p>Comments, bugs, suggestions? File an issue on <a href="https://github.com/alejandro5042/azdo-userscripts" target="_blank">GitHub</a> 🧡</p>
       `);

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -76,10 +76,13 @@
         'agent-arbitration-status-off': 'Off',
       });
 
-      eus.showTipOnce('release-2026-04-17', 'New in the AzDO userscript', `
-        <p>Highlights from the 2026-04-17 update!</p>
+      eus.showTipOnce('release-2026-05-20', 'New in the AzDO userscript', `
+        <p>Highlights from the 2026-05-20 update!</p>
+        <p>Changes to the PR dashboard view:</p>
         <ul>
-          <li>Switch from Rebrandly to GitHub for update URL (#247)</li>
+          <li>Source branch name is now shown for each PR.</li>
+          <li>Target branch name is hidden if it's <code>main</code> or <code>master</code>.</li>
+          <li>Branch names like <code>users/name/foo</code> are abbreviated to <code>u/n/foo</code>.</li>
         </ul>
         <p>Comments, bugs, suggestions? File an issue on <a href="https://github.com/alejandro5042/azdo-userscripts" target="_blank">GitHub</a> 🧡</p>
       `);


### PR DESCRIPTION
## Justification
When looking at the PR dashboard, I frequently want to see the name of the source branch for a given PR. I also almost never care about the target branch, because it's usually just `main` or `master`.

## Implementation
Add the source branch to all PRs. Hide the target branch (and related text and icon) if it's `main` or `master`. Update the README and update notification.

## Testing
Viewed some PRs into `main` and some into and from not-`main` and not-`user/...` to verify rendering:
<img width="919" height="230" alt="image" src="https://github.com/user-attachments/assets/d8594e98-89d1-4dd4-a180-9d4c00f63590" />
Also verified that the notification content renders as expected.