### PR TITLE
Add Resize handle to build left panel

### DIFF
--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1438,8 +1438,8 @@
 
   function watchForBuildResultsPage() {
     eus.onUrl(/\/(_build\/results)/gi, (session, urlMatch) => {
-      session.onEveryNew(document, '.bolt-master-panel', async tree => {
-        $('.bolt-master-panel').css('resize', 'horizontal');
+      session.onEveryNew(document, '.bolt-master-panel', panel => {
+        $(panel).css('resize', 'horizontal');
       });
     });
   }

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 
 // @name         More Awesome Azure DevOps (userscript)
-// @version      3.7.3
+// @version      3.7.4
 // @author       Alejandro Barreto (NI)
 // @description  Makes general improvements to the Azure DevOps experience, particularly around pull requests. Also contains workflow improvements for NI engineers.
 // @license      MIT
@@ -115,6 +115,7 @@
     watchForWorkItemForms();
     watchForNewDiffs(isDarkTheme);
     watchForShowMoreButtons();
+    watchForBuildResultsPage();
 
     if (atNI) {
       watchForDiffHeaders();
@@ -1431,6 +1432,14 @@
           // React will re-use this DOM element, so we need to re-enhance.
           session.onAnyChangeTo(row, () => enhancePullRequestRow(row, sectionTitle));
         });
+      });
+    });
+  }
+
+  function watchForBuildResultsPage() {
+    eus.onUrl(/\/(_build\/results)/gi, (session, urlMatch) => {
+      session.onEveryNew(document, '.bolt-master-panel', async tree => {
+        $('.bolt-master-panel').css('resize', 'horizontal');
       });
     });
   }


### PR DESCRIPTION
# Justification

It is hard to read the names of the tasks and jobs in the build results.

# Implementation

Add Resize

# Testing

##Before
![image](https://github.com/alejandro5042/azdo-userscripts/assets/8660999/75c70b27-3bbd-44a2-9c5e-a4319a7fbcb1)

## After
![image](https://github.com/alejandro5042/azdo-userscripts/assets/8660999/13678ff8-695e-4d1b-8104-ee64e50ed727)
