### PR TITLE
Display followers of a work item

### DIFF
--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1026,7 +1026,7 @@
 
     // Default to the window URL if the find operation fails
     let currentUrl = window.location.href;
-    if(workItemLink) {
+    if (workItemLink) {
       currentUrl = workItemLink.href;
     }
 

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -985,9 +985,10 @@
   }
 
   async function annotateWorkItemWithFollowerList(commentEditor) {
-    document.querySelectorAll('.work-item-followers-list').forEach(e => e.remove());
+    const commentEditorContainer = commentEditor.closest('.new-comment-div');
+    commentEditorContainer.querySelectorAll('.work-item-followers-list').forEach(e => e.remove());
 
-    const workItemId = getCurrentWorkItemId();
+    const workItemId = getCurrentWorkItemId(commentEditor);
     const queryResponse = await fetch(`${azdoApiBaseUrl}_apis/notification/subscriptionquery?api-version=6.0`, {
       method: 'POST',
       headers: {
@@ -1017,9 +1018,10 @@
     }
   }
 
-  function getCurrentWorkItemId() {
+  function getCurrentWorkItemId(commentEditor) {
     // Try getting the link from the work item header, in case this is opened in preview view
-    const header = document.querySelector('.work-item-form-header');
+    const workItemPage = commentEditor.closest('.work-item-form-page');
+    const header = workItemPage.querySelector('.work-item-form-header');
     const links = header.querySelectorAll('a');
     // Loop through the links and check if their target matches a link for a work item
     const workItemLink = Array.from(links).find(link => link.href.includes('_workitems'));


### PR DESCRIPTION
When Microsoft moved to the new Boards experience, support for displaying the list of followers was broken. This change fixes things for the newer Boards experience since that is now the default. 

## Main functional changes
* Updated minor version since this is a behavior change, but doesn't break compatibility
* Updated element reference to Follow button - used to refresh when a user clicks the follow button
* Updated element reference to the discussions area
   * Placed it below the text box to add a comment
* The work item number is no longer easily accessible since it is in an unnamed `div`. Created a helper function to extract the link from the work item header. 

## Minor changes
* Hide the followers list if there are no followers, instead of saying "Nobody"
* Updated links to open Teams instead of being mailto: links - this reflects modern workflows of defaulting to messaging someone on Teams. It assumes that the org uses Teams, however. 
   * I tried getting this to show up as a native "@mention" in Azure DevOps, but I couldn't get this to work

# Testing
* Ran `npm run build` - no warnings/errors
* Tested on Edge and Firefox
* Tested on dark and light themes
* Tested on work items opened normally and in a preview window (like from a dashboard or backlog view) 

<img width="1345" height="376" alt="image" src="https://github.com/user-attachments/assets/adf3c135-b6dc-495e-9087-3d976c759e66" />
<img width="1315" height="294" alt="image" src="https://github.com/user-attachments/assets/0da70a4e-fecd-4014-ace4-9ccc6b27daf6" />
