### PR TITLE
Update path in fetch request for known issues file.

### DIFF
--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1907,7 +1907,7 @@
 
         let queryResponse;
         try {
-          queryResponse = await fetch(`${azdoApiBaseUrl}/DevCentral/_apis/git/repositories/tools/items?path=/report/build_failure_analysis/pipeline-results/known-issues.json&api-version=6.0`);
+          queryResponse = await fetch(`${azdoApiBaseUrl}/DevCentral/_apis/git/repositories/tools/items?path=/report/build_failure_analysis/pipeline_results/known-issues.json&api-version=6.0`);
         } catch (err) {
           debug('Could not fetch known issues file from AzDO');
           return;


### PR DESCRIPTION
**Problem**: The `pipeline-results` folder was renamed to `pipeline_results` in PR !1071498, but the fetch request path in the known issues functionality was not updated accordingly causing the "Known Errors" to not show up.

**Solution**: Updated the `known-issues.json` file path in the fetch request to use the new `pipeline_results` directory name.

**Changes**
- Fixed path reference from pipeline-results to pipeline_results.

**Testing**
- Tested the change by updating the userscript in the ViolentMonkey Edge extension
- Verified that known issues are now displaying correctly:
<img width="570" height="152" alt="{5E8C25D4-C259-4256-9C4B-EDA788268D0D}" src="https://github.com/user-attachments/assets/5175b611-2280-4765-9c62-cfc4d0a24316" /><img width="1433" height="664" alt="image" src="https://github.com/user-attachments/assets/d82def13-12c1-456b-9d96-541a267ce90a" />