### PR TITLE
Correct labels container position to end of row

### DIFF
--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 
 // @name         More Awesome Azure DevOps (userscript)
-// @version      3.8.1
+// @version      3.8.2
 // @author       Alejandro Barreto (NI)
 // @description  Makes general improvements to the Azure DevOps experience, particularly around pull requests. Also contains workflow improvements for NI engineers.
 // @license      MIT
@@ -76,11 +76,10 @@
         'agent-arbitration-status-off': 'Off',
       });
 
-      eus.showTipOnce('release-2025-08-08', 'New in the AzDO userscript', `
-        <p>Highlights from the 2025-08-08 update!</p>
+      eus.showTipOnce('release-2026-04-15', 'New in the AzDO userscript', `
+        <p>Highlights from the 2026-04-15 update!</p>
         <ul>
-          <li>New: display the followers of a work item in the newer Boards view (#240).</li>
-          <li>Fix: navigating to the pull requests view from another AzDO page will now correctly show the organization pull requests page link. (#242)</li>
+          <li>Fix: correct labels container position in the PR dashboard. (#245)</li>
         </ul>
         <p>Comments, bugs, suggestions? File an issue on <a href="https://github.com/alejandro5042/azdo-userscripts" target="_blank">GitHub</a> 🧡</p>
       `);

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1693,7 +1693,7 @@
             <div class="bolt-pill-observe"></div>
           </div>
         </div>`)[0];
-      pullRequestRow.querySelector('.body-l').insertAdjacentElement('afterend', labelContainer);
+      pullRequestRow.querySelector('.bolt-table-two-line-cell-item').insertAdjacentElement('beforeend', labelContainer);
       labels = pullRequestRow.querySelector('.bolt-pill-group-inner');
     }
 


### PR DESCRIPTION
## Justification
On the PR dashboard, I noticed that the PR labels are rendered in different locations on different PRs. This looks like an error in the way we're creating the pill container if it's not already present.
![Current PR view](https://github.com/user-attachments/assets/35c72238-7746-4f9c-b216-e83440ffa9d9)

## Implementation
Add the pills container before the end of the containing element instead of as a sibling after the PR title. Bump the version and update the change notification.

## Testing
Testing in my browser, I now see the label pills always rendered after the title. I also sanity-checked the update notification.
![Updated PR view](https://github.com/user-attachments/assets/52cbfa4d-8244-42f3-89e0-ea97ed5f0a54)