### PR TITLE
Trim whitespace from OOO message before displaying

### DIFF
--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1206,7 +1206,7 @@
 
         const tooltipHtml = oooText
           ? `<p style='font-weight: bold; text-align: center'>This user is out of office:</p>
-          <p class="user-message">${escapeStringForHtml(oooText).replace(/\r?\n/ig, '<br><br>')}</p>`
+          <p class="user-message">${escapeStringForHtml(oooText).trim().replace(/\r?\n/ig, '<br><br>')}</p>`
           : '<p>This user is out of office but has not set an auto-reply message.</p>';
 
         annotateReviewer(nameElement, 'ooo', 'Out of Office', tooltipHtml);

--- a/src/azdo-pr-dashboard.user.js
+++ b/src/azdo-pr-dashboard.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 
 // @name         More Awesome Azure DevOps (userscript)
-// @version      3.13.0
+// @version      3.13.1
 // @author       Alejandro Barreto (NI)
 // @description  Makes general improvements to the Azure DevOps experience, particularly around pull requests. Also contains workflow improvements for NI engineers.
 // @license      MIT


### PR DESCRIPTION
# Justification
If a user has trailing newlines in their out-of-office message, we display that in our tooltip and it looks wonky. For example, this real out of office message:
<img width="790" height="412" alt="image" src="https://github.com/user-attachments/assets/03c80db8-3a22-4ec5-818a-3c35e580cd71" />

# Implementation
Trim the message before displaying. Bump our patch version, but don't touch the update notification tooltip because I don't think this is worth notifying people.

# Testing
The same message looks better now:
<img width="791" height="284" alt="image" src="https://github.com/user-attachments/assets/f2e800b4-8f86-46d5-8678-a6df7004328e" />